### PR TITLE
Add the experimental grabMove gestureLayout

### DIFF
--- a/examples/gestureLayouts/labs/grabMove/README.md
+++ b/examples/gestureLayouts/labs/grabMove/README.md
@@ -1,0 +1,33 @@
+# grabMove
+
+Move a window (in Linux) by grabbing it.
+
+Right now, this is only a proof-of-concept, and not intended for every-day use.
+
+## Using it
+
+* Hold your hand as flat as possible without tensing up.
+
+## The Gestures
+
+* Clicks
+    * Click: _Not implemented yet._
+    * Right click: Tilt your hand by 90 degrees, and then closing your hand. (Segment 1)
+    * Middle click: Turn your hand up-side down and closing your hand. ((Segment 2))
+    * Double click: Touch the action zone (push you hand all the way through the visible area until you hear a different dong.)
+* Scroll by turning your hand upside down and then moving your hand vertically.
+* Move a window: Grab and move your hand. When you're done, you can let go.
+* Keys
+    * CTRL: Introduce a second second and keep it flat.
+    * ALT: Introduce a second second and rotate it by 90 degrees. (Segment 1)
+    * Shift: Introduce a second second and turn it upside down. (Segment 2)
+
+## Considerations
+
+Watch the posture of your hand. It should be relatively flat and relaxed. If it's not, find out why and fix it (eg habbit? Is something difficult). If you have feedback for how to make this easier, please create an [issue on github](https://github.com/ksandom/handWavey/issues).
+
+As at 2022-08-03, this is the default gestureLayout for handWavey. Simply deleting these files in your config directory should be enough to get this configuration. But it is a nice reference for creating new layouts.
+
+## Target audience
+
+Proof-of-concept.

--- a/examples/gestureLayouts/labs/grabMove/actionEvents.yml
+++ b/examples/gestureLayouts/labs/grabMove/actionEvents.yml
@@ -1,0 +1,40 @@
+groups: {}
+items:
+  general-zone-pAction-enter:
+    value: lockCursor();rewindCursorPosition();doubleClick();
+  general-segment-p0-enter:
+    value: setButton("left");
+  general-segment-p1-enter:
+    value: setButton("right");
+  general-segment-p2-enter:
+    value: setButton("middle");overrideZone("scroll");
+  general-segment-p2-exit:
+    value: releaseZone();
+  general-segment-s0-enter:
+    value: keyDown("ctrl");
+  general-segment-s0-exit:
+    value: keyUp("ctrl");
+  general-segment-s1-enter:
+    value: keyDown("alt");
+  general-segment-s1-exit:
+    value: keyUp("alt");
+  general-segment-s2-exit:
+    value: keyUp("shift");
+  general-segment-s2-enter:
+    value: keyDown("shift");
+  general-state-pClosed-enter:
+    value: lockCursor();rewindCursorPosition();keyDown("alt");mouseDown();
+  general-state-pClosed-exit:
+    value: rewindCursorPosition();rewindScroll();releaseButtons();keyUp("alt");unlockCursor();
+  special-newHandUnfreezeEvent:
+    value: ""
+  special-newHandUnfreezeCursor:
+    value: ''
+  special-newHandFreeze:
+    value: ''
+  general-zone-sActive-exit:
+    value: releaseKeys();
+  general-state-pAbsent-enter:
+    value: setButton("left");releaseButtons();releaseKeys();releaseZone();
+  general-segment-pAnyChange:
+    value: lockCursor();rewindCursorPosition();

--- a/examples/gestureLayouts/labs/grabMove/gestureConfig.yml
+++ b/examples/gestureLayouts/labs/grabMove/gestureConfig.yml
@@ -1,0 +1,44 @@
+groups:
+  primaryHand:
+    groups: {}
+    items:
+      rotationSegments:
+        description: When you rotate your hand; it enters different segments. Increasing
+          the number of segments increases the number of things you can do with your
+          hand. Decreasing the number of segments makes it easier to be precise. Remember
+          that some segments are hard for a human hand to reach, so you need to keep
+          that in mind when choosing this number. It is expected that some segments
+          will be unused for this reason. Don't hurt yourself.
+        zzzEmpty: {}
+        defaultValue: '4'
+        oldValue: '4'
+        value: '4'
+      rotationOffset:
+        description: In radians. Adjust where the segments are slightly to cater
+          to your hand's natural bias.
+        zzzEmpty: {}
+        defaultValue: '0'
+        oldValue: '0'
+        value: '0'
+  secondaryHand:
+    groups: {}
+    items:
+      rotationSegments:
+        description: When you rotate your hand; it enters different segments. Increasing
+          the number of segments increases the number of things you can do with your
+          hand. Decreasing the number of segments makes it easier to be precise. Remember
+          that some segments are hard for a human hand to reach, so you need to keep
+          that in mind when choosing this number. It is expected that some segments
+          will be unused for this reason. Don't hurt yourself.
+        zzzEmpty: {}
+        defaultValue: '4'
+        oldValue: '4'
+        value: '4'
+      rotationOffset:
+        description: In radians. Adjust where the segments are slightly to cater
+          to your hand's natural bias.
+        zzzEmpty: {}
+        defaultValue: '0'
+        oldValue: '0'
+        value: '0'
+items: {}


### PR DESCRIPTION
This doesn't need to be merged at the moment. I just wanted to share the proof-of-concept we did on the phone. I'll have a think and refine it to something more useful soon.

The two lines I modified are:

```diff
ksandom@delli:~/files/develop/handWavey/examples/gestureLayouts/labs/grabMove$ diff ../../grabClick/actionEvents.yml actionEvents.yml 
26c26
<     value: lockCursor();rewindCursorPosition();mouseDown();
---
>     value: lockCursor();rewindCursorPosition();keyDown("alt");mouseDown();
28c28
<     value: rewindCursorPosition();rewindScroll();releaseButtons();unlockCursor();
---
>     value: rewindCursorPosition();rewindScroll();releaseButtons();keyUp("alt");unlockCursor();
```

Something I forgot to mention when we talked; is that the event names you see in the YAML file are not the only ones you can use. You can make any combination of states to form an event. I have documenting this on my to-dos, but you can also get clues about possible events from the default debug level.