### PR TITLE
Fix grab recognition

### DIFF
--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -181,6 +181,10 @@ public class HandWaveyConfig {
             "openThreshold",
             "1.8",
             "Float: When the last bone of the middle finger is less than this angle, the hand is assumed to be open.");
+        ultraMotion.newItem(
+            "openFinger",
+            "3",
+            "Int: Which finger to use to determine that the hand is open or closed. If you are having incorrect open/closed state, this is the first thing to check. Have a look at the \"Leap Motion Diagnostic Visualizer\" to see what every finger is doing when you see the incorrect behavior. On the devices that I've tested so far, finger 1 and 2 (pointing and index) are regularly in the incorrect state, while other fingers seem to be fine.");
         Group coneOfSilence = ultraMotion.newGroup("coneOfSilence");
         coneOfSilence.newItem(
             "maxHeight",

--- a/src/main/java/ultraMotion/UltraMotionInput.java
+++ b/src/main/java/ultraMotion/UltraMotionInput.java
@@ -35,17 +35,21 @@ public class UltraMotionInput extends Listener {
     
     private Boolean activeHandsExist = false;
     
-    private int fingerToUse = 2;
+    private int fingerToUse = 3;
     private Bone.Type boneToUse = null;
 
     public UltraMotionInput () {
         this.boneToUse = Bone.Type.values()[Bone.Type.values().length-1];
         
+        this.debug = Debug.getDebug("UltraMotionInput");
+        
         Group ultraMotionConfig = Config.singleton().getGroup("ultraMotion");
         this.openThreshold = Float.parseFloat(ultraMotionConfig.getItem("openThreshold").get());
         this.maxHands = Integer.parseInt(ultraMotionConfig.getItem("maxHands").get());
+        this.fingerToUse = Integer.parseInt(ultraMotionConfig.getItem("openFinger").get());
         
-        this.debug = Debug.getDebug("UltraMotionInput");
+        this.debug.out(1, "Finger to use for open/closed state: " + String.valueOf(this.fingerToUse));
+        this.debug.out(1, "Open/closed threshold: " + String.valueOf(this.openThreshold));
         
         // Configure the cone of silence for ignoring input from outside the reliable cone.
         Group conOfSilence = ultraMotionConfig.getGroup("coneOfSilence");


### PR DESCRIPTION
On my device, the left two fingers are often getting stuck. The second is the one that is being used for the grab gesture. Since the other two fingers have not been getting stuck in my testing, this might be enough to fix it. If not, I'll look at other solutions.

I've added a configuration item for this in ultraMotion.yml so that if this assumption breaks for someone else, they can choose a different finger.

Note: That this is working around a bug in LeapMotion's interpretation of what it's seeing, not a bug with handWavey.