### PR TITLE
Make custom- event naming more intuitive and flexible

### DIFF
--- a/docs/user/howTo/createADynamicGestureLayout.md
+++ b/docs/user/howTo/createADynamicGestureLayout.md
@@ -58,270 +58,33 @@ Custom events are what get triggered by the slots.
 
 These are the default actions for the custom events:
 
-* Special
-  * custom-0: Release keys and buttons. (Return state.)
-  * custom-1:
-  * custom-2:
-  * custom-3:
-  * custom-4:
-  * custom-5:
-  * custom-6:
-  * custom-7:
-  * custom-8:
-  * custom-9:
-* Basic clicks
-  * custom-10: Mouse down - Left.
-  * custom-11: Mouse down - Right.
-  * custom-12: Mouse down - Middle.
-  * custom-13:
-  * custom-14:
-  * custom-15:
-  * custom-16:
-  * custom-17:
-  * custom-18:
-  * custom-19:
-* Multi clicks
-  * custom-20: Double click hold.
-  * custom-21: Tripple click hold.
-  * custom-22: Double click.
-  * custom-23: Tripple click.
-  * custom-24:
-  * custom-25:
-  * custom-26:
-  * custom-27:
-  * custom-28:
-  * custom-29:
-* Modified clicks
-  * custom-30: ALT + Left click.
-  * custom-31: ALT + Right click.
-  * custom-32: ALT + Middle click.
-  * custom-33:
-  * custom-34:
-  * custom-35:
-  * custom-36:
-  * custom-37:
-  * custom-38:
-  * custom-39:
-  * custom-40: CTRL + Left click.
-  * custom-41: CTRL + Right click.
-  * custom-42: CTRL + Middle click.
-  * custom-43:
-  * custom-44:
-  * custom-45:
-  * custom-46:
-  * custom-47:
-  * custom-48:
-  * custom-49:
-* Currently unassigned, but intended for modified clicks. Move there as needed.
-  * custom-50:
-  * custom-51:
-  * custom-52:
-  * custom-53:
-  * custom-54:
-  * custom-55:
-  * custom-56:
-  * custom-57:
-  * custom-58:
-  * custom-59:
-  * custom-60:
-  * custom-61:
-  * custom-62:
-  * custom-63:
-  * custom-64:
-  * custom-65:
-  * custom-66:
-  * custom-67:
-  * custom-68:
-  * custom-69:
-  * custom-70:
-  * custom-71:
-  * custom-72:
-  * custom-73:
-  * custom-74:
-  * custom-75:
-  * custom-76:
-  * custom-77:
-  * custom-78:
-  * custom-79:
-  * custom-80:
-  * custom-81:
-  * custom-82:
-  * custom-83:
-  * custom-84:
-  * custom-85:
-  * custom-86:
-  * custom-87:
-  * custom-88:
-  * custom-89:
-  * custom-90:
-  * custom-91:
-  * custom-92:
-  * custom-93:
-  * custom-94:
-  * custom-95:
-  * custom-96:
-  * custom-97:
-  * custom-98:
-  * custom-99:
-* Keyboard shortcuts (No state-return needed.)
-  * custom-100:
-  * custom-101: CTRL + c
-  * custom-102: CTRL + v
-  * custom-103: CTRL + x
-  * custom-104: Delete
-  * custom-105: CTRL + z
-  * custom-106: CTRL + SHIFT + z
-* Currently unassigned, but intended for keyboard shortcuts. Move as needed.
-  * custom-107:
-  * custom-108:
-  * custom-109:
-  * custom-110:
-  * custom-111:
-  * custom-112:
-  * custom-113:
-  * custom-114:
-  * custom-115:
-  * custom-116:
-  * custom-117:
-  * custom-118:
-  * custom-119:
-  * custom-120:
-  * custom-121:
-  * custom-122:
-  * custom-123:
-  * custom-124:
-  * custom-125:
-  * custom-126:
-  * custom-127:
-  * custom-128:
-  * custom-129:
-  * custom-130:
-  * custom-131:
-  * custom-132:
-  * custom-133:
-  * custom-134:
-  * custom-135:
-  * custom-136:
-  * custom-137:
-  * custom-138:
-  * custom-139:
-  * custom-140:
-  * custom-141:
-  * custom-142:
-  * custom-143:
-  * custom-144:
-  * custom-145:
-  * custom-146:
-  * custom-147:
-  * custom-148:
-  * custom-149:
-  * custom-150:
-  * custom-151:
-  * custom-152:
-  * custom-153:
-  * custom-154:
-  * custom-155:
-  * custom-156:
-  * custom-157:
-  * custom-158:
-  * custom-159:
-  * custom-160:
-  * custom-161:
-  * custom-162:
-  * custom-163:
-  * custom-164:
-  * custom-165:
-  * custom-166:
-  * custom-167:
-  * custom-168:
-  * custom-169:
-  * custom-170:
-  * custom-171:
-  * custom-172:
-  * custom-173:
-  * custom-174:
-  * custom-175:
-  * custom-176:
-  * custom-177:
-  * custom-178:
-  * custom-179:
-* Scroll
-  * custom-180: Scroll - Turn off.
-  * custom-181: Scroll - Turn on.
-  * custom-182: CTRL + Scroll - Turn on.
-  * custom-183:
-  * custom-184:
-  * custom-185:
-  * custom-186:
-  * custom-187:
-  * custom-188:
-  * custom-189:
-  * custom-190:
-  * custom-191:
-  * custom-192:
-  * custom-193:
-  * custom-194:
-  * custom-195:
-  * custom-196:
-  * custom-197:
-  * custom-198:
-  * custom-199:
-* Currently unassigned.
-  * custom-200:
-  * custom-201:
-  * custom-202:
-  * custom-203:
-  * custom-204:
-  * custom-205:
-  * custom-206:
-  * custom-207:
-  * custom-208:
-  * custom-209:
-  * custom-210:
-  * custom-211:
-  * custom-212:
-  * custom-213:
-  * custom-214:
-  * custom-215:
-  * custom-216:
-  * custom-217:
-  * custom-218:
-  * custom-219:
-  * custom-220:
-  * custom-221:
-  * custom-222:
-  * custom-223:
-  * custom-224:
-  * custom-225:
-  * custom-226:
-  * custom-227:
-  * custom-228:
-  * custom-229:
-  * custom-230:
-  * custom-231:
-  * custom-232:
-  * custom-233:
-  * custom-234:
-  * custom-235:
-  * custom-236:
-  * custom-237:
-  * custom-238:
-  * custom-239:
-  * custom-240:
-  * custom-241:
-  * custom-242:
-  * custom-243:
-  * custom-244:
-  * custom-245:
-  * custom-246:
-  * custom-247:
-  * custom-248:
-  * custom-249:
-  * custom-250:
-  * custom-251:
-  * custom-252:
-  * custom-253:
-  * custom-254:
-* Special
-  * custom-255: Do nothing.
+<!-- BEGIN custom- table. -->
+| custom- event | Description |
+| --- | --- |
+| custom-noOp | Do nothing. Useful to have a blank slot that can sometimes be used for other things. |
+| custom-releaseAll | Release all buttons and keys. Useful for getting the keyboard and mouse into a known state. |
+| custom-mouseDown-left | Press down the left mouse button. |
+| custom-mouseDown-right | Press down the right mouse button. |
+| custom-mouseDown-middle | Press down the middle mouse button. |
+| custom-releaseZone | Release and zone overrides. This is typically used at the end of overriding the zone for something like scrolling. |
+| custom-override-scroll | Override the zone to scroll. This has the effect that any movement of the hand causes scroll movement instead of mouse cursor movement. |
+| custom-override-ctrl+scroll | Press the CTRL key down, and override the zone to scroll. Often this is used for zooming. |
+| custom-doubleClick-hold | Double click the left button, without lifting the finger at the end of the second click. This is useful for doing things like drag-selecting by word rather than by character. |
+| custom-trippleClick-hold | Tripple click the left button, without lifting the finger at the end of the second click. This is useful for doing things like drag-selecting by line rather than by character. |
+| custom-doubleClick | Double click the left button. |
+| custom-trippleClick | Tripple click the left button. |
+| custom-alt+mouseDown-left | Press the ALT key, then hold down the left button. |
+| custom-alt+mouseDown-right | Press the ALT key, then hold down the right button. |
+| custom-alt+mouseDown-middle | Press the ALT key, then hold down the middle button. |
+| custom-ctrl+mouseDown-left | Press the CTRL key, then hold down the left button. |
+| custom-ctrl+mouseDown-right | Press the CTRL key, then hold down the right button. |
+| custom-ctrl+mouseDown-middle | Press the CTRL key, then hold down the middle button. |
+| custom-ctrl+c | CTRL + C. Typically used for copying a selection. |
+| custom-ctrl+v | CTRL + v. Typically used for pasting. |
+| custom-ctrl+x | CTRL + x. Typically used for cutting a selection. |
+| custom-delete | Press and release the delete key. |
+| custom-ctrl+z | CTRL + z. Typically used for undo. |
+| custom-ctrl+shift+z | CTRL + Shift z. Typically used for re-doing an undone task. |
+<!-- END custom- table. -->
 
+This table can be automatically updated with `./generateCustomTable.sh`. It's generated from  generateCustomConfig function in [HandWaveyConfig.java](https://github.com/ksandom/handWavey/blob/main/src/main/java/handWavey/HandWaveyConfig.java#L576) that sets the defaults.

--- a/docs/user/howTo/generateCustomTable.sh
+++ b/docs/user/howTo/generateCustomTable.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Generate a table of custom- events that can be used in gestureLayouts, and insert it into the createAGestureLayout.md document.
+
+srcFile="createADynamicGestureLayout.md"
+backupFile="${srcFile}.backup"
+customDefaultFile="../../../src/main/java/handWavey/HandWaveyConfig.java"
+
+function prep
+{
+    cp -v "$srcFile" "$backupFile"
+}
+
+function cleanup
+{
+    rm -v "$backupFile"
+}
+
+function generateTable
+{
+    echo "| custom- event | Description |"
+    echo "| --- | --- |"
+    grep 'customGroup.getItem("' "$customDefaultFile" | sed 's/^.*"custom-/| custom-/g; s/".*\/\/ / | /g; s/$/ |/g'
+}
+
+function getHead
+{
+    grep -B10000 "BEGIN custom- table." "$backupFile"
+}
+
+function getFoot
+{
+    grep -A10000 "END custom- table." "$backupFile"
+}
+
+prep
+getHead > "$srcFile"
+generateTable >> "$srcFile"
+getFoot >> "$srcFile"
+cleanup

--- a/examples/gestureLayouts/tiltClick/actionModifier/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/actionModifier/actionEvents.yml
@@ -11,19 +11,19 @@ items:
   individual-pAction1Open-enter:
     value: debug("0", "Toolset = Copy/paste.");
   individual-pAction1Closed-enter:
-    value: setAllSlots("");setSlot("0", "custom-101");setSlot("1", "custom-12");setSlot("3", "custom-11");
+    value: setAllSlots("");setSlot("0", "custom-mouseDown-left1");setSlot("1", "custom-mouseDown-middle");setSlot("3", "custom-mouseDown-right");
   individual-pAction3Open-enter:
     value: debug("0", "Toolset = Modified click.");
   individual-pAction3Closed-enter:
-    value: setAllSlots("");setSlot("0", "custom-30");setSlot("1", "custom-31");setSlot("2", "custom-40");setSlot("3", "custom-41");setSlot("4", "custom-182");
+    value: setAllSlots("");setSlot("0", "custom-alt+mouseDown-left");setSlot("1", "custom-alt+mouseDown-right");setSlot("2", "custom-ctrl+mouseDown-left");setSlot("3", "custom-ctrl+mouseDown-left");setSlot("4", "custom-override-ctrl+scroll");
   individual-pAction8Open-enter:
     value: debug("0", "Toolset = Web.");
   individual-pAction8Closed-enter:
-    value: setAllSlots("");setSlot("1", "custom-102");setSlot("2", "custom-103");setSlot("3", "custom-104");
+    value: setAllSlots("");setSlot("1", "custom-mouseDown-left2");setSlot("2", "custom-mouseDown-left3");setSlot("3", "custom-mouseDown-left4");
   individual-pAction9Open-enter:
     value: debug("0", "Toolset = Multi-click.");
   individual-pAction9Closed-enter:
-    value: setAllSlots("");setSlot("0", "custom-20");setSlot("1", "custom-21");setSlot("2", "custom-22");setSlot("3", "custom-23");
+    value: setAllSlots("");setSlot("0", "custom-doubleClick-hold");setSlot("1", "custom-trippleClick-hold");setSlot("2", "custom-doubleClic");setSlot("3", "custom-trippleClick");
   general-segment-p0-enter:
     value: ""
   general-segment-p2-enter:
@@ -59,25 +59,25 @@ items:
   general-segment-pAnyChange:
     value: lockCursor();rewindCursorPosition();
   individual-pNonOOB1Open-enter:
-    value: doSlot("0", "custom-10");
+    value: doSlot("0", "custom-mouseDown-left");
   individual-pNonOOB1Open-exit:
-    value: doSlot("5", "custom-0");
+    value: doSlot("5", "custom-releaseAll");
   individual-pNonOOB9Open-enter:
-    value: doSlot("1", "custom-11");
+    value: doSlot("1", "custom-mouseDown-right");
   individual-pNonOOB9Open-exit:
-    value: doSlot("6", "custom-0");
+    value: doSlot("6", "custom-releaseAll");
   individual-pNonOOB0Closed-enter:
-    value: doSlot("4", "custom-181");
+    value: doSlot("4", "custom-override-scroll");
   individual-pNonOOB0Closed-exit:
-    value: doSlot("9", "custom-180");
+    value: doSlot("9", "custom-releaseZone");
   individual-pNonOOB1Closed-enter:
-    value: doSlot("2", "custom-255");
+    value: doSlot("2", "custom-noOp");
   individual-pNonOOB1Closed-exit:
-    value: doSlot("7", "custom-0");
+    value: doSlot("7", "custom-releaseAll");
   individual-pNonOOB9Closed-enter:
-    value: doSlot("3", "custom-255");
+    value: doSlot("3", "custom-noOp");
   individual-pNonOOB9Closed-exit:
-    value: doSlot("8", "custom-0");
+    value: doSlot("8", "custom-releaseAll");
   general-state-pAbsent-enter:
     value: setButton("left");releaseButtons();releaseKeys();releaseZone();
   individual-pOOB0Absent-enter:

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -580,29 +580,29 @@ public class HandWaveyConfig {
         customGroup.addItemTemplate("custom-.*", "", "A custom event that a user can trigger in a gestureLayout. It is intended to be used with slots, and can be read about in createADynamicGestureLayout.md.");
 
         // Set the default values.
-        customGroup.getItem("custom-255").overrideDefault("debug(\"0\", \"No action is currently assigned to this slot.\");");
-        customGroup.getItem("custom-0").overrideDefault("rewindCursorPosition();rewindScroll();releaseButtons();releaseKeys();unlockCursor();");
-        customGroup.getItem("custom-10").overrideDefault("setButton(\"left\");lockCursor();rewindCursorPosition();mouseDown();");
-        customGroup.getItem("custom-11").overrideDefault("setButton(\"right\");lockCursor();rewindCursorPosition();mouseDown();");
-        customGroup.getItem("custom-12").overrideDefault("setButton(\"middle\");lockCursor();rewindCursorPosition();mouseDown();");
-        customGroup.getItem("custom-180").overrideDefault("rewindCursorPosition();releaseZone();unlockCursor();");
-        customGroup.getItem("custom-181").overrideDefault("rewindCursorPosition();overrideZone(\"scroll\");releaseKeys();");
-        customGroup.getItem("custom-182").overrideDefault("rewindCursorPosition();keyDown(\"ctrl\");overrideZone(\"scroll\");");
-        customGroup.getItem("custom-20").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");click();mouseDown();");
-        customGroup.getItem("custom-21").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();mouseDown();");
-        customGroup.getItem("custom-22").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();");
-        customGroup.getItem("custom-23").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();click();");
-        customGroup.getItem("custom-30").overrideDefault("keyDown(\"alt\");setButton(\"left\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"alt\");");
-        customGroup.getItem("custom-31").overrideDefault("keyDown(\"alt\");setButton(\"right\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"alt\");");
-        customGroup.getItem("custom-32").overrideDefault("keyDown(\"alt\");setButton(\"middle\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"alt\");");
-        customGroup.getItem("custom-40").overrideDefault("keyDown(\"ctrl\");setButton(\"left\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"ctrl\");");
-        customGroup.getItem("custom-41").overrideDefault("keyDown(\"ctrl\");setButton(\"right\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"ctrl\");");
-        customGroup.getItem("custom-42").overrideDefault("keyDown(\"ctrl\");setButton(\"middle\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"ctrl\");");
-        customGroup.getItem("custom-101").overrideDefault("keyDown(\"ctrl\");keyDown(\"c\");keyUp(\"c\");keyUp(\"ctrl\");");
-        customGroup.getItem("custom-102").overrideDefault("keyDown(\"ctrl\");keyDown(\"v\");keyUp(\"v\");keyUp(\"ctrl\");");
-        customGroup.getItem("custom-103").overrideDefault("keyDown(\"ctrl\");keyDown(\"x\");keyUp(\"x\");keyUp(\"ctrl\");");
-        customGroup.getItem("custom-104").overrideDefault("keyDown(\"delete\");keyUp(\"delete\");");
-        customGroup.getItem("custom-105").overrideDefault("keyDown(\"ctrl\");keyDown(\"z\");keyUp(\"z\");keyUp(\"ctrl\");");
-        customGroup.getItem("custom-106").overrideDefault("keyDown(\"ctrl\");keyDown(\"shift\");keyDown(\"z\");keyUp(\"z\");keyUp(\"shift\");keyUp(\"ctrl\");");
+        customGroup.getItem("custom-noOp").overrideDefault("debug(\"0\", \"No action is currently assigned to this slot.\");");
+        customGroup.getItem("custom-releaseAll").overrideDefault("rewindCursorPosition();rewindScroll();releaseButtons();releaseKeys();unlockCursor();");
+        customGroup.getItem("custom-mouseDown-left").overrideDefault("setButton(\"left\");lockCursor();rewindCursorPosition();mouseDown();");
+        customGroup.getItem("custom-mouseDown-right").overrideDefault("setButton(\"right\");lockCursor();rewindCursorPosition();mouseDown();");
+        customGroup.getItem("custom-mouseDown-middle").overrideDefault("setButton(\"middle\");lockCursor();rewindCursorPosition();mouseDown();");
+        customGroup.getItem("custom-releaseZone").overrideDefault("rewindCursorPosition();releaseZone();unlockCursor();");
+        customGroup.getItem("custom-override-scroll").overrideDefault("rewindCursorPosition();overrideZone(\"scroll\");releaseKeys();");
+        customGroup.getItem("custom-override-ctrl+scroll").overrideDefault("rewindCursorPosition();keyDown(\"ctrl\");overrideZone(\"scroll\");");
+        customGroup.getItem("custom-doubleClick-hold").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");click();mouseDown();");
+        customGroup.getItem("custom-trippleClick-hold").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();mouseDown();");
+        customGroup.getItem("custom-doubleClick").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();");
+        customGroup.getItem("custom-trippleClick").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();click();");
+        customGroup.getItem("custom-alt+mouseDown-left").overrideDefault("keyDown(\"alt\");setButton(\"left\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"alt\");");
+        customGroup.getItem("custom-alt+mouseDown-right").overrideDefault("keyDown(\"alt\");setButton(\"right\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"alt\");");
+        customGroup.getItem("custom-alt+mouseDown-middle").overrideDefault("keyDown(\"alt\");setButton(\"middle\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"alt\");");
+        customGroup.getItem("custom-ctrl+mouseDown-left").overrideDefault("keyDown(\"ctrl\");setButton(\"left\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"ctrl\");");
+        customGroup.getItem("custom-ctrl+mouseDown-right").overrideDefault("keyDown(\"ctrl\");setButton(\"right\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"ctrl\");");
+        customGroup.getItem("custom-ctrl+mouseDown-middle").overrideDefault("keyDown(\"ctrl\");setButton(\"middle\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"ctrl\");");
+        customGroup.getItem("custom-ctrl+c").overrideDefault("keyDown(\"ctrl\");keyDown(\"c\");keyUp(\"c\");keyUp(\"ctrl\");");
+        customGroup.getItem("custom-ctrl+v").overrideDefault("keyDown(\"ctrl\");keyDown(\"v\");keyUp(\"v\");keyUp(\"ctrl\");");
+        customGroup.getItem("custom-ctrl+x").overrideDefault("keyDown(\"ctrl\");keyDown(\"x\");keyUp(\"x\");keyUp(\"ctrl\");");
+        customGroup.getItem("custom-delete").overrideDefault("keyDown(\"delete\");keyUp(\"delete\");");
+        customGroup.getItem("custom-ctrl+z").overrideDefault("keyDown(\"ctrl\");keyDown(\"z\");keyUp(\"z\");keyUp(\"ctrl\");");
+        customGroup.getItem("custom-ctrl+shift+z").overrideDefault("keyDown(\"ctrl\");keyDown(\"shift\");keyDown(\"z\");keyUp(\"z\");keyUp(\"shift\");keyUp(\"ctrl\");");
     }
 }

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -580,29 +580,29 @@ public class HandWaveyConfig {
         customGroup.addItemTemplate("custom-.*", "", "A custom event that a user can trigger in a gestureLayout. It is intended to be used with slots, and can be read about in createADynamicGestureLayout.md.");
 
         // Set the default values.
-        customGroup.getItem("custom-noOp").overrideDefault("debug(\"0\", \"No action is currently assigned to this slot.\");");
-        customGroup.getItem("custom-releaseAll").overrideDefault("rewindCursorPosition();rewindScroll();releaseButtons();releaseKeys();unlockCursor();");
-        customGroup.getItem("custom-mouseDown-left").overrideDefault("setButton(\"left\");lockCursor();rewindCursorPosition();mouseDown();");
-        customGroup.getItem("custom-mouseDown-right").overrideDefault("setButton(\"right\");lockCursor();rewindCursorPosition();mouseDown();");
-        customGroup.getItem("custom-mouseDown-middle").overrideDefault("setButton(\"middle\");lockCursor();rewindCursorPosition();mouseDown();");
-        customGroup.getItem("custom-releaseZone").overrideDefault("rewindCursorPosition();releaseZone();unlockCursor();");
-        customGroup.getItem("custom-override-scroll").overrideDefault("rewindCursorPosition();overrideZone(\"scroll\");releaseKeys();");
-        customGroup.getItem("custom-override-ctrl+scroll").overrideDefault("rewindCursorPosition();keyDown(\"ctrl\");overrideZone(\"scroll\");");
-        customGroup.getItem("custom-doubleClick-hold").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");click();mouseDown();");
-        customGroup.getItem("custom-trippleClick-hold").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();mouseDown();");
-        customGroup.getItem("custom-doubleClick").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();");
-        customGroup.getItem("custom-trippleClick").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();click();");
-        customGroup.getItem("custom-alt+mouseDown-left").overrideDefault("keyDown(\"alt\");setButton(\"left\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"alt\");");
-        customGroup.getItem("custom-alt+mouseDown-right").overrideDefault("keyDown(\"alt\");setButton(\"right\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"alt\");");
-        customGroup.getItem("custom-alt+mouseDown-middle").overrideDefault("keyDown(\"alt\");setButton(\"middle\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"alt\");");
-        customGroup.getItem("custom-ctrl+mouseDown-left").overrideDefault("keyDown(\"ctrl\");setButton(\"left\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"ctrl\");");
-        customGroup.getItem("custom-ctrl+mouseDown-right").overrideDefault("keyDown(\"ctrl\");setButton(\"right\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"ctrl\");");
-        customGroup.getItem("custom-ctrl+mouseDown-middle").overrideDefault("keyDown(\"ctrl\");setButton(\"middle\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"ctrl\");");
-        customGroup.getItem("custom-ctrl+c").overrideDefault("keyDown(\"ctrl\");keyDown(\"c\");keyUp(\"c\");keyUp(\"ctrl\");");
-        customGroup.getItem("custom-ctrl+v").overrideDefault("keyDown(\"ctrl\");keyDown(\"v\");keyUp(\"v\");keyUp(\"ctrl\");");
-        customGroup.getItem("custom-ctrl+x").overrideDefault("keyDown(\"ctrl\");keyDown(\"x\");keyUp(\"x\");keyUp(\"ctrl\");");
-        customGroup.getItem("custom-delete").overrideDefault("keyDown(\"delete\");keyUp(\"delete\");");
-        customGroup.getItem("custom-ctrl+z").overrideDefault("keyDown(\"ctrl\");keyDown(\"z\");keyUp(\"z\");keyUp(\"ctrl\");");
-        customGroup.getItem("custom-ctrl+shift+z").overrideDefault("keyDown(\"ctrl\");keyDown(\"shift\");keyDown(\"z\");keyUp(\"z\");keyUp(\"shift\");keyUp(\"ctrl\");");
+        customGroup.getItem("custom-noOp").overrideDefault("debug(\"0\", \"No action is currently assigned to this slot.\");"); // Do nothing. Useful to have a blank slot that can sometimes be used for other things.
+        customGroup.getItem("custom-releaseAll").overrideDefault("rewindCursorPosition();rewindScroll();releaseButtons();releaseKeys();unlockCursor();"); // Release all buttons and keys. Useful for getting the keyboard and mouse into a known state.
+        customGroup.getItem("custom-mouseDown-left").overrideDefault("setButton(\"left\");lockCursor();rewindCursorPosition();mouseDown();"); // Press down the left mouse button.
+        customGroup.getItem("custom-mouseDown-right").overrideDefault("setButton(\"right\");lockCursor();rewindCursorPosition();mouseDown();"); // Press down the right mouse button.
+        customGroup.getItem("custom-mouseDown-middle").overrideDefault("setButton(\"middle\");lockCursor();rewindCursorPosition();mouseDown();"); // Press down the middle mouse button.
+        customGroup.getItem("custom-releaseZone").overrideDefault("rewindCursorPosition();releaseZone();unlockCursor();"); // Release and zone overrides. This is typically used at the end of overriding the zone for something like scrolling.
+        customGroup.getItem("custom-override-scroll").overrideDefault("rewindCursorPosition();overrideZone(\"scroll\");releaseKeys();"); // Override the zone to scroll. This has the effect that any movement of the hand causes scroll movement instead of mouse cursor movement.
+        customGroup.getItem("custom-override-ctrl+scroll").overrideDefault("rewindCursorPosition();keyDown(\"ctrl\");overrideZone(\"scroll\");"); // Press the CTRL key down, and override the zone to scroll. Often this is used for zooming.
+        customGroup.getItem("custom-doubleClick-hold").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");click();mouseDown();"); // Double click the left button, without lifting the finger at the end of the second click. This is useful for doing things like drag-selecting by word rather than by character.
+        customGroup.getItem("custom-trippleClick-hold").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();mouseDown();"); // Tripple click the left button, without lifting the finger at the end of the second click. This is useful for doing things like drag-selecting by line rather than by character.
+        customGroup.getItem("custom-doubleClick").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();"); // Double click the left button.
+        customGroup.getItem("custom-trippleClick").overrideDefault("lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();click();"); // Tripple click the left button.
+        customGroup.getItem("custom-alt+mouseDown-left").overrideDefault("keyDown(\"alt\");setButton(\"left\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"alt\");"); // Press the ALT key, then hold down the left button.
+        customGroup.getItem("custom-alt+mouseDown-right").overrideDefault("keyDown(\"alt\");setButton(\"right\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"alt\");"); // Press the ALT key, then hold down the right button.
+        customGroup.getItem("custom-alt+mouseDown-middle").overrideDefault("keyDown(\"alt\");setButton(\"middle\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"alt\");"); // Press the ALT key, then hold down the middle button.
+        customGroup.getItem("custom-ctrl+mouseDown-left").overrideDefault("keyDown(\"ctrl\");setButton(\"left\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"ctrl\");"); // Press the CTRL key, then hold down the left button.
+        customGroup.getItem("custom-ctrl+mouseDown-right").overrideDefault("keyDown(\"ctrl\");setButton(\"right\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"ctrl\");"); // Press the CTRL key, then hold down the right button.
+        customGroup.getItem("custom-ctrl+mouseDown-middle").overrideDefault("keyDown(\"ctrl\");setButton(\"middle\");lockCursor();rewindCursorPosition();mouseDown();keyUp(\"ctrl\");"); // Press the CTRL key, then hold down the middle button.
+        customGroup.getItem("custom-ctrl+c").overrideDefault("keyDown(\"ctrl\");keyDown(\"c\");keyUp(\"c\");keyUp(\"ctrl\");"); // CTRL + c. Typically used for copying a selection.
+        customGroup.getItem("custom-ctrl+v").overrideDefault("keyDown(\"ctrl\");keyDown(\"v\");keyUp(\"v\");keyUp(\"ctrl\");"); // CTRL + v. Typically used for pasting.
+        customGroup.getItem("custom-ctrl+x").overrideDefault("keyDown(\"ctrl\");keyDown(\"x\");keyUp(\"x\");keyUp(\"ctrl\");"); // CTRL + x. Typically used for cutting a selection.
+        customGroup.getItem("custom-delete").overrideDefault("keyDown(\"delete\");keyUp(\"delete\");"); // Press and release the delete key.
+        customGroup.getItem("custom-ctrl+z").overrideDefault("keyDown(\"ctrl\");keyDown(\"z\");keyUp(\"z\");keyUp(\"ctrl\");"); // CTRL + z. Typically used for undo.
+        customGroup.getItem("custom-ctrl+shift+z").overrideDefault("keyDown(\"ctrl\");keyDown(\"shift\");keyDown(\"z\");keyUp(\"z\");keyUp(\"shift\");keyUp(\"ctrl\");"); // CTRL + Shift z. Typically used for re-doing an undone task.
     }
 }


### PR DESCRIPTION
This makes config and debug output much easier to read and write. Eg:

Old

* custom-1
* custom-2
* custom-3
* custom-4
* ...

New

* custom-mouseDown-left
* custom-releaseAll
* custom-alt+mouseDown-left
* custom-ctrl+c
* ...

It also makes the documentation much simpler.