### PR TITLE
Remove stray quote

### DIFF
--- a/docs/user/install/libraries.md
+++ b/docs/user/install/libraries.md
@@ -31,7 +31,7 @@ This will copy everything that is relevant in one easy step.
 where `/path/to/LeapSDK` is where you extracted the LeapSDK. Eg:
 
 ```bash
-./getPrerequisites.sh '~/Downloads/LeapDeveloperKit_2.3.1+31549_linux
+./getPrerequisites.sh ~/Downloads/LeapDeveloperKit_2.3.1+31549_linux
 ```
 
 #### clean.sh


### PR DESCRIPTION
Remove a stray quote from the example.

Not an urgent fix. But one that could cause confusion. So worth including in the next release.