### PR TITLE
Add Guava to Windows Gradle config

### DIFF
--- a/build.gradle.windows
+++ b/build.gradle.windows
@@ -22,7 +22,8 @@ dependencies {
     runtimeOnly files('lib/LeapJava.jar')
     implementation 'com.shinyhut:vernacular:1.14'
     implementation "org.yaml:snakeyaml:1.21"
-
+    implementation "com.google.guava:guava:31.1-jre"
+    
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }


### PR DESCRIPTION
The build was failing on Windows due to Google Guava missing from the Gradle config. I have added it.