### PR TITLE
Add limit to how many sounds can play concurrently

### DIFF
--- a/src/main/java/audio/BackgroundSound.java
+++ b/src/main/java/audio/BackgroundSound.java
@@ -7,10 +7,21 @@ Play a .WAV file in a new thread so that it does not block the current thread.
 package audio;
 
 import bug.ShouldComplete;
+import debug.Debug;
+import config.*;
+import handWavey.HandWaveyEvent;
+import java.io.File;
+
 
 public class BackgroundSound extends Thread {
     private String fileName;
     private static ShouldComplete shouldCompleteSound = null;
+    private static int concurrentCount = 0;
+    private static int maxCount = 8;
+    private static Boolean maxExceeded = false;
+    private static Debug debug = Debug.getDebug("BackgroundSound");
+    private static Boolean configured = false;
+    private static String bugPath = "";
 
     public BackgroundSound(String fileName) {
         this.fileName = fileName;
@@ -21,11 +32,26 @@ public class BackgroundSound extends Thread {
         player.playSound(this.fileName);
     }
 
+    public static void play(String fileName) {
+        if (!BackgroundSound.begin()) {
+            BackgroundSound.end();
+            if (maxExceeded == false) {
+                // Only play the bug noise once per incident.
+                BackgroundSound.playBugNotification();
+                maxExceeded = true;
+            }
+
+            return ;
+        }
+
+        BackgroundSound.playFile(fileName);
+    }
+
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
         value="LI_LAZY_INIT_STATIC",
         justification="There might be a better way of doing this. But it really doesn't matter if this isn't 100% reliable. The purpose of shouldComplete is to help catch something not finishing. If it fails the first time, it'll catch it the second time.")
 
-    public static void play(String fileName) {
+    private static void playFile(String fileName) {
         if (BackgroundSound.shouldCompleteSound == null) {
             BackgroundSound.shouldCompleteSound = new ShouldComplete("BackgroundSound/play");
         }
@@ -36,5 +62,50 @@ public class BackgroundSound extends Thread {
         sound.start();
 
         BackgroundSound.shouldCompleteSound.finish();
+    }
+
+    private static void playBugNotification() {
+        BackgroundSound.playFile(BackgroundSound.bugPath);
+    }
+
+    public static Boolean begin() {
+        Boolean result = true;
+        BackgroundSound.concurrentCount++;
+
+        BackgroundSound.setup();
+
+        if (BackgroundSound.concurrentCount > BackgroundSound.maxCount) {
+            BackgroundSound.debug.out(1, "Reached maxCount. Not going to play any more sounds until this subsides.");
+            result = false;
+        }
+
+        return result;
+    }
+
+    public static void end() {
+        BackgroundSound.concurrentCount--;
+
+        if (BackgroundSound.concurrentCount == 0) {
+            maxExceeded = false;
+        }
+    }
+
+    private static void setup() {
+        // Immediately return if it's already configured.
+        if (BackgroundSound.configured) {
+            return ;
+        }
+
+        // Set up how the limit for how many sounds can play at once.
+        BackgroundSound.maxCount = Integer.parseInt(Config.singleton().getGroup("audioConfig").getItem("maxCount").get());
+
+        // Figure out the file to play.
+        String audioPath = Config.singleton().getGroup("audioConfig").getItem("pathToAudio").get() + File.separator;
+        String bugFile = Config.singleton().getGroup("audioEvents").getItem("bug").get();
+
+        BackgroundSound.bugPath = audioPath + bugFile;
+
+        // Make sure we don't do this again for this session.
+        BackgroundSound.configured = true;
     }
 }

--- a/src/main/java/audio/SimplePlayer.java
+++ b/src/main/java/audio/SimplePlayer.java
@@ -32,7 +32,6 @@ class SimplePlayer {
          * @param filename the name of the file that is going to be played
          */
         public void playSound(String filename){
-
             String strFilename = filename;
 
             try {
@@ -79,5 +78,7 @@ class SimplePlayer {
 
             sourceLine.drain();
             sourceLine.close();
+
+            BackgroundSound.end();
         }
 }

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -146,6 +146,10 @@ public class HandWaveyConfig {
             "bug.ShouldComplete.MacroLine.line-.*",
             "0",
             "Int: Sensible numbers are 0-2, where 0 will only tell you when a bug has been detected. 1 tells you what has been started, and 2 tells you what has completed as well (this is probably redundant, since level 0 still tells you on the next round when something hasn't finished.) Generally you'll want to keep this at 0. But if want to see that something is even being attempted, this will help. This entry is for the individual macro instructions at nesting level denoted at the end of this setting name.");
+        debug.addItemTemplate(
+            "BackgroundSound",
+            "1",
+            "Int: Sensible numbers are 0-1, where 0 will not tell anything. And 1 tells you when ever the maxCount has been exceeded.");
 
         Group dataCleaning = this.config.newGroup("dataCleaning");
         dataCleaning.newItem(
@@ -497,6 +501,10 @@ public class HandWaveyConfig {
             "pathToAudio",
             "audio" + File.separator + "clips",
             "Where are all of the audio clips stored.");
+        audioConfig.newItem(
+            "maxCount",
+            "8",
+            "How many audio clips can play concurrently.");
 
         Group audioEvents = this.config.newGroup("audioEvents");
         audioEvents.newItem(


### PR DESCRIPTION
This is so that when things do go wrong, it doesn't trash the sound system (eg pipewire/pulseaudio).