### PR TITLE
Add missing recalibrateSegments();

### DIFF
--- a/examples/gestureLayouts/grabClick/actionEvents.yml
+++ b/examples/gestureLayouts/grabClick/actionEvents.yml
@@ -29,7 +29,7 @@ items:
   special-newHandUnfreezeEvent:
     value: ""
   special-newHandUnfreezeCursor:
-    value: ''
+    value: 'recalibrateSegments();'
   special-newHandFreeze:
     value: ''
   general-zone-sActive-exit:

--- a/examples/gestureLayouts/tiltClick/actionModifier/audioEvents.yml
+++ b/examples/gestureLayouts/tiltClick/actionModifier/audioEvents.yml
@@ -19,7 +19,7 @@ items:
   special-newHandUnfreezeEvent:
     value: ''
   special-newHandUnfreezeCursor:
-    value: ''
+    value: 'recalibrateSegments();'
   individual-pAction0Open-enter:
     value: piano-short-C1.wav
   individual-pAction1Open-enter:

--- a/examples/gestureLayouts/tiltClick/closeDoubleClick/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/closeDoubleClick/actionEvents.yml
@@ -29,7 +29,7 @@ items:
   special-newHandUnfreezeEvent:
     value: ""
   special-newHandUnfreezeCursor:
-    value: ''
+    value: 'recalibrateSegments();'
   special-newHandFreeze:
     value: ''
   general-segment-p1-enter:
@@ -40,9 +40,9 @@ items:
     value: setButton("left");lockCursor();rewindCursorPosition();mouseDown();
   individual-pNonOOB1Open-exit:
     value: rewindCursorPosition();releaseButtons();unlockCursor();
-  individual-pNonOOB5Open-enter:
+  individual-pNonOOB7Open-enter:
     value: setButton("right");lockCursor();rewindCursorPosition();mouseDown();
-  individual-pNonOOB5Open-exit:
+  individual-pNonOOB7Open-exit:
     value: rewindCursorPosition();releaseButtons();unlockCursor();
   individual-pNonOOB1Closed-enter:
     value: lockCursor();rewindCursorPosition();releaseButtons();setButton("left");doubleClick();
@@ -52,9 +52,9 @@ items:
     value: rewindCursorPosition();overrideZone("scroll");
   individual-pNonOOB0Closed-exit:
     value: rewindCursorPosition();releaseZone();unlockCursor();
-  individual-pNonOOB5Closed-enter:
+  individual-pNonOOB7Closed-enter:
     value: setButton("middle");lockCursor();rewindCursorPosition();mouseDown();
-  individual-pNonOOB5Closed-exit:
+  individual-pNonOOB7Closed-exit:
     value: rewindCursorPosition();rewindScroll();releaseButtons();unlockCursor();
   general-state-pAbsent-enter:
     value: setButton("left");releaseButtons();releaseKeys();releaseZone();

--- a/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
@@ -29,7 +29,7 @@ items:
   special-newHandUnfreezeEvent:
     value: ""
   special-newHandUnfreezeCursor:
-    value: ''
+    value: 'recalibrateSegments();'
   special-newHandFreeze:
     value: ''
   general-segment-p1-enter:
@@ -40,9 +40,9 @@ items:
     value: setButton("left");lockCursor();rewindCursorPosition();mouseDown();
   individual-pNonOOB1Open-exit:
     value: rewindCursorPosition();releaseButtons();unlockCursor();
-  individual-pNonOOB5Open-enter:
+  individual-pNonOOB7Open-enter:
     value: setButton("right");lockCursor();rewindCursorPosition();mouseDown();
-  individual-pNonOOB5Open-exit:
+  individual-pNonOOB7Open-exit:
     value: rewindCursorPosition();releaseButtons();unlockCursor();
   individual-pNonOOB1Closed-enter:
     value: setButton("middle");lockCursor();rewindCursorPosition();mouseDown();
@@ -52,9 +52,9 @@ items:
     value: rewindCursorPosition();overrideZone("scroll");
   individual-pNonOOB0Closed-exit:
     value: rewindCursorPosition();releaseZone();unlockCursor();
-  individual-pNonOOB5Closed-enter:
+  individual-pNonOOB7Closed-enter:
     value: rewindCursorPosition();setButton("left");doubleClick();
-  individual-pNonOOB5Closed-exit:
+  individual-pNonOOB7Closed-exit:
     value: rewindCursorPosition();unlockCursor();
   general-state-pAbsent-enter:
     value: setButton("left");releaseButtons();releaseKeys();releaseZone();

--- a/examples/gestureLayouts/tiltClick/zoom/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/zoom/actionEvents.yml
@@ -29,7 +29,7 @@ items:
   special-newHandUnfreezeEvent:
     value: ""
   special-newHandUnfreezeCursor:
-    value: ''
+    value: 'recalibrateSegments();'
   special-newHandFreeze:
     value: ''
   general-segment-p1-enter:
@@ -40,9 +40,9 @@ items:
     value: setButton("left");lockCursor();rewindCursorPosition();mouseDown();
   individual-pNonOOB1Open-exit:
     value: rewindCursorPosition();releaseButtons();unlockCursor();
-  individual-pNonOOB5Open-enter:
+  individual-pNonOOB7Open-enter:
     value: setButton("right");lockCursor();rewindCursorPosition();mouseDown();
-  individual-pNonOOB5Open-exit:
+  individual-pNonOOB7Open-exit:
     value: rewindCursorPosition();releaseButtons();unlockCursor();
   individual-pNonOOB1Closed-enter:
     value: setButton("middle");lockCursor();rewindCursorPosition();mouseDown();

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -488,7 +488,7 @@ public class HandWaveyConfig {
             "When a new primary hand is introduced, the cursor and the ability to click the mouse or press keys, is disabled while the device stabilises.");
         actionEvents.newItem(
             "special-newHandUnfreezeCursor",
-            "",
+            "recalibrateSegments();",
             "When the time has expired for the Cursor freeze after a new primary hand is introduced.");
         actionEvents.newItem(
             "special-newHandUnfreezeEvent",


### PR DESCRIPTION
Whoopsies.

This PR fixes:

* Add missing recalibrateSegments(); - One of the big benefits of [the previous PR](https://github.com/ksandom/handWavey/pull/46) essentially wasn't enabled.
* Also fix right-click on several layouts. - I simply missed this in my testing.

I did a lot of testing around this. Unfortunately my testing relied on my local config, which never made it back into the code.