### PR TITLE
Add autoTrim

### DIFF
--- a/docs/user/configuration/autoCalibration.md
+++ b/docs/user/configuration/autoCalibration.md
@@ -1,0 +1,46 @@
+# Auto calibration
+
+It used to be that calibration of the roll axis was done in the gestureLayout via `rotationOffset`. This worked reasonably well. But assumptions that worked well for one user were not necessarily the same for the next user. Heck, those assumptions didn't even hold up for one person from one moment to the next.
+
+`rotationOffset` has therefore been removed entirely and has been replaced with:
+
+* `recalibrateSegments();` - A macro command, typically called by the `special-newHandUnfreezeCursor` event.
+* `autoTrim`. - Constant adjustment based on how far the hand is from the center of the current segment.
+
+## recalibrateSegments
+
+### What & how
+
+`recalibrateSegments();` does the heavy lifting.
+
+Every time you enter your hand into the view of the device, this command gets called once the hand has had a chance to stabilise. What ever the roll current is, an offset of that amount is taken into account for every calculation involving segments for the remainder of the time that the hand is visible.
+
+### Why
+
+This has the effect that handWavey is immediately calibrated to the newly introduced hand, regardless of whose it is. Users can just do what is comfortable, and it will work.
+
+### Configuration
+
+This is configured in the actionEvents.yml within the [gestureLayout](https://github.com/ksandom/handWavey/blob/main/docs/user/howTo/createAGestureLayout.md).
+
+You can disable this behaviour be removing the `recalibrateSegments();` from the actionEvents.yml file.
+
+## autoTrim
+
+### What & how
+
+For every sample measuring your hand:
+
+* The rotational distance from the center of the segment is captured.
+* Based on the rotational distance, an offset (independant of `recalibrateSegments();`) is adjusted:
+    * The rate of change is limited by `autoTrimMaxChangePerSecond` within handCleaner.yml.
+        * Setting this to `0` disables this feature.
+    * The total change is limited by `autoTrimMaxChange` within handCleaner.yml.
+
+### Why
+
+Ideally, intentional movements will go straight through, while unintentional movements will be transparently adjusted for.
+
+### Configuration
+
+Adjust `autoTrimMaxChangePerSecond` abd `autoTrimMaxChange` within handCleaner.yml.

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -484,7 +484,7 @@ public class HandWaveyConfig {
         Group actionEvents = this.config.newGroup("actionEvents"); // Entirely generated in Gesture.
         actionEvents.newItem(
             "special-newHandFreeze",
-            "recalibrateSegments();",
+            "",
             "When a new primary hand is introduced, the cursor and the ability to click the mouse or press keys, is disabled while the device stabilises.");
         actionEvents.newItem(
             "special-newHandUnfreezeCursor",
@@ -608,6 +608,14 @@ public class HandWaveyConfig {
             "movingMeanFinger",
             "20",
             "The moving mean length for the finger (used for whether the hand is open or closed). >0. 1 effectively disables the moving mean. A larger number is more effective at removing noise, at the expense of responsiveness.");
+        handCleaner.newItem(
+            "autoTrimMaxChangePerSecond",
+            "0.3",
+            "The maximum change (in radians) that the auto-trim can apply per second. It is applied proportionally based on the duration since the last sample. The goal of auto-trim is to adjust to changes in the resting position of the hand so that segments still feel intuitive to the user despite the user not being consistent. Setting this to 0 disables autoTrim.");
+        handCleaner.newItem(
+            "autoTrimMaxChange",
+            "1.57",
+            "The maximum change (in radians) that the auto-trim can apply in total. Setting this too small will limit how much auto-trim can help you. Setting it too large could lead to confusing behavior. The goal of auto-trim is to adjust to changes in the resting position of the hand so that segments still feel intuitive to the user despite the user not being consistent.");
     }
 
     private void generateCustomConfig(Group customGroup) {

--- a/src/main/java/handWavey/HandsState.java
+++ b/src/main/java/handWavey/HandsState.java
@@ -188,8 +188,15 @@ public class HandsState {
                 this.primaryState.setZone(zone);
             }
 
-            this.primaryState.setSegment(getHandSegment(true, this.handSummaries[0], this.cleanPrimary));
+            int segment = getHandSegment(true, this.handSummaries[0], this.cleanPrimary);
+            this.primaryState.setSegment(segment);
             this.primaryState.setState(this.cleanPrimary.getState());
+
+            double distanceFromCenter = this.getSegmentDistanceFromCenter(segment, true, this.handSummaries[0], this.cleanPrimary);
+
+            this.cleanPrimary.autoTrim(distanceFromCenter);
+
+            //this.debug.out(0, "Distance from center: " + String.valueOf(distanceFromCenter));
         }
 
         if (this.handSummaries[1] == null || !this.handSummaries[1].isValid()) {
@@ -339,6 +346,29 @@ public class HandsState {
         }
 
         return segmentNumber;
+    }
+
+    public double getSegmentDistanceFromCenter(int segment, Boolean isPrimary, HandSummary handSummary, HandCleaner cleanHand) {
+        return  getSegmentDistanceFromCenter(cleanHand.getHandRoll(), segment, isPrimary, handSummary.handIsLeft());
+    }
+
+    public double getSegmentDistanceFromCenter(double handRoll, int segment, Boolean isPrimary, Boolean isLeft) {
+        // Flip the direction depending on the hand.
+        int directionalMultiplier = (isLeft)?1:-1;
+        double handedRoll = handRoll * directionalMultiplier;
+
+        // Get the current segmentWidth.
+        double segmentWidth = (isPrimary)?this.primarySegmentWidth:this.secondarySegmentWidth;
+
+        // Take care of, moving the range into the positive, move 0 into the center of segment 0, and add the user-specified offset.
+        double userOffset = (isPrimary)?this.primaryOffset:this.secondaryOffset;
+        double offsetRoll = handedRoll - userOffset;
+
+        double segmentPosition = (segmentWidth * segment);
+
+        double distanceFromSegmentCenter = segmentPosition - offsetRoll;
+
+        return distanceFromSegmentCenter;
     }
 
     private String deriveZone(double handZ) {

--- a/src/test/java/handWavey/TestState.java
+++ b/src/test/java/handWavey/TestState.java
@@ -83,9 +83,15 @@ class TestState {
         Group gestureConfig = config.getGroup("gestureConfig");
         Group primaryHand = gestureConfig.getGroup("primaryHand");
         primaryHand.getItem("rotationSegments").set("4");
+        primaryHand.getItem("mergeIntoSegment").set("0");
+        primaryHand.getItem("mergeFrom").set("0");
+        primaryHand.getItem("mergeTo").set("0");
 
         Group secondaryHand = gestureConfig.getGroup("secondaryHand");
         secondaryHand.getItem("rotationSegments").set("4");
+        secondaryHand.getItem("mergeIntoSegment").set("0");
+        secondaryHand.getItem("mergeFrom").set("0");
+        secondaryHand.getItem("mergeTo").set("0");
 
         this.handsState = new HandsState();
     }


### PR DESCRIPTION
This trims the hand roll to account for the user being inconsistent with their roll input. A quick motion will get past the trim and the event will be triggered. But a slow/unintentional movement will get caught by the autoTrim.

Trim is adjusted against the center of the current segment.