### PR TITLE
Fix unfreeze unit test

### DIFF
--- a/src/test/java/handWavey/TestGesture.java
+++ b/src/test/java/handWavey/TestGesture.java
@@ -92,7 +92,7 @@ class TestGesture {
         assertEquals("", actionEvents.getItem("individual-pOOB0Absent-exit").get());
 
         // Special events.
-        assertEquals("recalibrateSegments();", actionEvents.getItem("special-newHandFreeze").get());
+        assertEquals("recalibrateSegments();", actionEvents.getItem("special-newHandUnfreezeCursor").get());
     }
 
     @Test


### PR DESCRIPTION
I had moved which event was being used to recalibrate the hand, but hadn't updated the unit test. This fixes that.