### PR TITLE
Fix the most frustrating handWavey bug

### DIFF
--- a/src/main/java/handWavey/HandsState.java
+++ b/src/main/java/handWavey/HandsState.java
@@ -183,10 +183,9 @@ public class HandsState {
         if (shouldUpdatePrimary) {
             primaryHandZ = this.cleanPrimary.getHandZ() * this.zMultiplier;
 
+            String rawZone = this.handsState.getZone(primaryHandZ, false);
+            this.primaryState.setZone(rawZone);
             String zone = this.handsState.getZone(primaryHandZ);
-            if (!zone.equals(this.zoneOverride)) {
-                this.primaryState.setZone(zone);
-            }
 
             int primarySegment = getHandSegment(true, this.handSummaries[0], this.cleanPrimary);
             this.primaryState.setSegment(primarySegment);


### PR DESCRIPTION
This has been the most frustrating, persistent and illusive bug in handWavey. But once I was able to consistently reproduce the bug, it suddenly became much easier to solve.

## The fix

* Make sure the zone gets registered when overridden.

## Why

When the zone was being overridden, it would not be tracked as changed when the hand moved between zones. This manifested itself as a huge amount of event spam when inserting the hand in a closed state.