### PR TITLE
Stablise closed hand gestures

### DIFF
--- a/examples/gestureLayouts/tiltClick/doubleClick/README.md
+++ b/examples/gestureLayouts/tiltClick/doubleClick/README.md
@@ -10,9 +10,10 @@
     * Click: Tilt your hand off to the side it naturally wants to turn.
     * Right click: Tilt your hand slightly unnaturally.
     * Middle click: Close your hand, then tilt to the side it naturally wants to turn.
-    * Double click: 
+    * Double click:
       * Touch the action zone.
       * Hand in neutral position. Close your hand. Rotate slightly unnaturally.
+    * Tripple click: Tap with closed hand (like a slight punching motion.)
 * Scroll: Hand in neutral position. Close your hand. Move hand up/down.
 * Keys <!-- (nice to haves) -->
     * CTRL: Introduce secondary hard. Tilt slightly unnaturally.

--- a/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
@@ -73,13 +73,13 @@ items:
   custom-disallowWheelClicks:
     value: setSlot("0", "custom-noop");setSlot("1", "custom-noop");setSlot("10", "custom-noop");setSlot("11", "custom-custom-noop");
   custom-closedLeft-enter:
-    value: setSlot("3", "custom-noop");setButton("middle");lockCursor();rewindCursorPosition();mouseDown();lockTaps("primary");cancelDelayedDo("custom-tap-left");
+    value: setSlot("3", "custom-noop");setButton("middle");rewindCursorPosition();mouseDown();lockTaps("primary");cancelDelayedDo("custom-trippleClick");
   custom-closedLeft-exit:
-    value: rewindCursorPosition();rewindScroll();releaseButtons();unlockCursor();unlockTaps("primary", "600");
+    value: rewindCursorPosition();rewindScroll();releaseButtons();unlockTaps("primary", "600");cancelDelayedDo("custom-trippleClick");
   custom-closedRight-enter:
-    value: setSlot("3", "custom-noop");rewindCursorPosition();setButton("left");doubleClick();lockTaps("primary");cancelDelayedDo("custom-tap-left");
+    value: setSlot("3", "custom-noop");rewindCursorPosition();setButton("left");doubleClick();lockTaps("primary");cancelDelayedDo("custom-trippleClick");
   custom-closedRight-exit:
-    value: rewindCursorPosition();unlockCursor();unlockTaps("primary", "600");
+    value: rewindCursorPosition();unlockTaps("primary", "600");cancelDelayedDo("custom-trippleClick");
   custom-doScroll:
     value: rewindCursorPosition();overrideZone("scroll");setSlot("3", "custom-noop");do("custom-disallowWheelClicks");lockTaps("primary");
   custom-noop:

--- a/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
@@ -23,9 +23,9 @@ items:
   general-zone-sActive-exit:
     value: releaseKeys();
   general-state-pClosed-enter:
-    value: ""
+    value: lockCursor();do("custom-allowWheelClicks");setSlot("3", "custom-doScroll");lockTaps("primary");cancelDelayedDo("custom-tap-left");
   general-state-pClosed-exit:
-    value: ""
+    value: unlockCursor();do("custom-allowWheelClicks");setSlot("3", "custom-noop");rewindCursorPosition();releaseZone();unlockCursor();unlockTaps("primary", "600");
   special-newHandUnfreezeEvent:
     value: ""
   special-newHandUnfreezeCursor:
@@ -45,20 +45,40 @@ items:
   individual-pNonOOB6Open-exit:
     value: rewindCursorPosition();releaseButtons();unlockCursor();unlockTaps("primary");
   individual-pNonOOB1Closed-enter:
-    value: setButton("middle");lockCursor();rewindCursorPosition();mouseDown();lockTaps("primary");cancelDelayedDo("custom-tap-left");
+    value: doSlot("0", "custom-noop");
   individual-pNonOOB1Closed-exit:
-    value: rewindCursorPosition();rewindScroll();releaseButtons();unlockCursor();unlockTaps("primary", "600");
+    value: doSlot("10", "custom-noop");
   individual-pNonOOB0Closed-enter:
-    value: rewindCursorPosition();overrideZone("scroll");lockTaps("primary");cancelDelayedDo("custom-tap-left");
+    value: ""
   individual-pNonOOB0Closed-exit:
-    value: rewindCursorPosition();releaseZone();unlockCursor();unlockTaps("primary", "600");
+    value: ""
   individual-pNonOOB6Closed-enter:
-    value: rewindCursorPosition();setButton("left");doubleClick();lockTaps("primary");cancelDelayedDo("custom-tap-left");
+    value: doSlot("1", "custom-noop");
   individual-pNonOOB6Closed-exit:
-    value: rewindCursorPosition();unlockCursor();unlockTaps("primary", "600");
+    value: doSlot("11", "custom-noop");
   general-state-pAbsent-enter:
     value: setButton("left");releaseButtons();releaseKeys();releaseZone();unlockTaps("primary");cancelDelayedDo("custom-tap-left");
   tap-p0Open:
     value: delayedDo("custom-tap-left", "150");
   custom-tap-left:
     value: setButton("left");lockCursor();rewindCursorPosition("150");mouseDown();mouseUp();unlockCursor();
+  special-primaryMoving:
+    value: lockGestures("primary");doSlot("3", "noop");
+  special-primaryStationary:
+    value: unlockGestures("primary");
+  custom-allowWheelClicks:
+    value: setSlot("0", "custom-closedLeft-enter");setSlot("1", "custom-closedRight-enter");setSlot("10", "custom-closedLeft-exit");setSlot("11", "custom-closedRight-exit");
+  custom-disallowWheelClicks:
+    value: setSlot("0", "custom-noop");setSlot("1", "custom-noop");setSlot("10", "custom-noop");setSlot("11", "custom-custom-noop");
+  custom-closedLeft-enter:
+    value: setButton("middle");lockCursor();rewindCursorPosition();mouseDown();lockTaps("primary");cancelDelayedDo("custom-tap-left");
+  custom-closedLeft-exit:
+    value: rewindCursorPosition();rewindScroll();releaseButtons();unlockCursor();unlockTaps("primary", "600");
+  custom-closedRight-enter:
+    value: rewindCursorPosition();setButton("left");doubleClick();lockTaps("primary");cancelDelayedDo("custom-tap-left");
+  custom-closedRight-exit:
+    value: rewindCursorPosition();unlockCursor();unlockTaps("primary", "600");
+  custom-doScroll:
+    value: rewindCursorPosition();overrideZone("scroll");setSlot("3", "custom-noop");do("custom-disallowWheelClicks");
+  custom-noop:
+    value: ""

--- a/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
@@ -23,9 +23,9 @@ items:
   general-zone-sActive-exit:
     value: releaseKeys();
   general-state-pClosed-enter:
-    value: lockCursor();do("custom-allowWheelClicks");setSlot("3", "custom-doScroll");lockTaps("primary");cancelDelayedDo("custom-tap-left");
+    value: lockCursor();do("custom-allowWheelClicks");setSlot("3", "custom-doScroll");cancelDelayedDo("custom-tap-left");
   general-state-pClosed-exit:
-    value: unlockCursor();do("custom-allowWheelClicks");setSlot("3", "custom-noop");rewindCursorPosition();releaseZone();unlockCursor();unlockTaps("primary", "600");
+    value: cancelDelayedDo("custom-trippleClick");unlockCursor();do("custom-allowWheelClicks");setSlot("3", "custom-noop");rewindCursorPosition();releaseZone();unlockCursor();unlockTaps("primary", "600");
   special-newHandUnfreezeEvent:
     value: ""
   special-newHandUnfreezeCursor:
@@ -60,6 +60,8 @@ items:
     value: setButton("left");releaseButtons();releaseKeys();releaseZone();unlockTaps("primary");cancelDelayedDo("custom-tap-left");
   tap-p0Open:
     value: delayedDo("custom-tap-left", "150");
+  tap-p0Closed:
+    value: delayedDo("custom-trippleClick", "150");
   custom-tap-left:
     value: setButton("left");lockCursor();rewindCursorPosition("150");mouseDown();mouseUp();unlockCursor();
   special-primaryMoving:
@@ -79,6 +81,6 @@ items:
   custom-closedRight-exit:
     value: rewindCursorPosition();unlockCursor();unlockTaps("primary", "600");
   custom-doScroll:
-    value: rewindCursorPosition();overrideZone("scroll");setSlot("3", "custom-noop");do("custom-disallowWheelClicks");
+    value: rewindCursorPosition();overrideZone("scroll");setSlot("3", "custom-noop");do("custom-disallowWheelClicks");lockTaps("primary");
   custom-noop:
     value: ""

--- a/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
@@ -73,14 +73,14 @@ items:
   custom-disallowWheelClicks:
     value: setSlot("0", "custom-noop");setSlot("1", "custom-noop");setSlot("10", "custom-noop");setSlot("11", "custom-custom-noop");
   custom-closedLeft-enter:
-    value: setSlot("3", "custom-noop");setButton("middle");rewindCursorPosition();mouseDown();lockTaps("primary");cancelDelayedDo("custom-trippleClick");
+    value: setSlot("3", "custom-noop");cancelDelayedDo("custom-disallowWheelClicks");setButton("middle");rewindCursorPosition();mouseDown();lockTaps("primary");cancelDelayedDo("custom-trippleClick");
   custom-closedLeft-exit:
     value: rewindCursorPosition();rewindScroll();releaseButtons();unlockTaps("primary", "600");cancelDelayedDo("custom-trippleClick");
   custom-closedRight-enter:
-    value: setSlot("3", "custom-noop");rewindCursorPosition();setButton("left");doubleClick();lockTaps("primary");cancelDelayedDo("custom-trippleClick");
+    value: setSlot("3", "custom-noop");cancelDelayedDo("custom-disallowWheelClicks");rewindCursorPosition();setButton("left");doubleClick();lockTaps("primary");cancelDelayedDo("custom-trippleClick");
   custom-closedRight-exit:
     value: rewindCursorPosition();unlockTaps("primary", "600");cancelDelayedDo("custom-trippleClick");
   custom-doScroll:
-    value: rewindCursorPosition();overrideZone("scroll");setSlot("3", "custom-noop");do("custom-disallowWheelClicks");lockTaps("primary");
+    value: rewindCursorPosition();overrideZone("scroll");setSlot("3", "custom-noop");delayedDo("custom-disallowWheelClicks", "150");lockTaps("primary");
   custom-noop:
     value: ""

--- a/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
@@ -73,11 +73,11 @@ items:
   custom-disallowWheelClicks:
     value: setSlot("0", "custom-noop");setSlot("1", "custom-noop");setSlot("10", "custom-noop");setSlot("11", "custom-custom-noop");
   custom-closedLeft-enter:
-    value: setButton("middle");lockCursor();rewindCursorPosition();mouseDown();lockTaps("primary");cancelDelayedDo("custom-tap-left");
+    value: setSlot("3", "custom-noop");setButton("middle");lockCursor();rewindCursorPosition();mouseDown();lockTaps("primary");cancelDelayedDo("custom-tap-left");
   custom-closedLeft-exit:
     value: rewindCursorPosition();rewindScroll();releaseButtons();unlockCursor();unlockTaps("primary", "600");
   custom-closedRight-enter:
-    value: rewindCursorPosition();setButton("left");doubleClick();lockTaps("primary");cancelDelayedDo("custom-tap-left");
+    value: setSlot("3", "custom-noop");rewindCursorPosition();setButton("left");doubleClick();lockTaps("primary");cancelDelayedDo("custom-tap-left");
   custom-closedRight-exit:
     value: rewindCursorPosition();unlockCursor();unlockTaps("primary", "600");
   custom-doScroll:


### PR DESCRIPTION
On the tilt-click gestureLayouts, I have several gestures involving the closed hand.

Before now, it was easy to accidentally trigger unwanted events. This change effectively chooses a path, and eliminates the other possibilities, which makes the whole process significantly more stable. Eg if you start scrolling, you're probably not wanting to double, or middle click. And if you double, or middle click, you probably don't want to scroll.

Something that has become painfully apparent is that this code is not maintainable. So I've only implemented it on the "doubleClick" gestureLayout for now, and in a few days, I'm going to release another PR that will make this much more maintainable.