### PR TITLE
Stablise entry

### DIFF
--- a/src/main/java/handWavey/HandCleaner.java
+++ b/src/main/java/handWavey/HandCleaner.java
@@ -265,6 +265,10 @@ public class HandCleaner {
         return (speed < stationarySpeed);
     }
 
+    public Boolean isZStationary() {
+        return (Math.abs(zSpeed) < tapSpeed);
+    }
+
     public void setGestureLock(Boolean desiredState) {
         this.gesturesLocked = desiredState;
     }
@@ -358,7 +362,7 @@ public class HandCleaner {
         }
 
         // Have we met the speed threshold for a tap?
-        if (Math.abs(zSpeed) < tapSpeed) {
+        if (isZStationary()) {
             return false;
         }
 

--- a/src/main/java/handWavey/HandStateEvents.java
+++ b/src/main/java/handWavey/HandStateEvents.java
@@ -23,6 +23,7 @@ public class HandStateEvents {
     private Changed segmentChanged = new Changed(0, "segmentChanged");
     private Changed stateChanged = new Changed(Gesture.absent, "stateChanged");
     private Changed stationaryChanged = new Changed(1, "stationaryChanged");
+    private Changed zStationaryChanged = new Changed(1, "zStationaryChanged");
     private Changed tapChanged = new Changed(0, "tapChanged");
 
     private List<String> anyChangeEvents = new ArrayList<String>();
@@ -41,21 +42,23 @@ public class HandStateEvents {
         this.gesture = new Gesture();
     }
 
-    public void setTimeouts(long zoneTimeout, long OOBTimeout, long segmentTimeout, long stateTimeout, long stationaryTimeout) {
+    public void setTimeouts(long zoneTimeout, long OOBTimeout, long segmentTimeout, long stateTimeout, long stationaryTimeout, long zStationaryTimeout) {
         //this.zoneChanged.setTimeout(zoneTimeout);
         this.OOBChanged.setTimeout(OOBTimeout);
         this.segmentChanged.setTimeout(segmentTimeout);
         this.stateChanged.setTimeout(stateTimeout);
         this.stationaryChanged.setTimeout(stationaryTimeout);
+        this.zStationaryChanged.setTimeout(zStationaryTimeout);
         // this.tapChanged.setTimeout(tapTimeout);
     }
 
-    public void enableTimeouts(Boolean zoneEnabled, Boolean OOBEnabled, Boolean segmentEnabled, Boolean stateEnabled, Boolean stationaryEnabled) {
+    public void enableTimeouts(Boolean zoneEnabled, Boolean OOBEnabled, Boolean segmentEnabled, Boolean stateEnabled, Boolean stationaryEnabled, Boolean zStationaryEnabled) {
         //this.zoneChanged.enableTimeout(zoneEnabled);
         this.OOBChanged.enableTimeout(OOBEnabled);
         this.segmentChanged.enableTimeout(segmentEnabled);
         this.stateChanged.enableTimeout(stateEnabled);
         this.stationaryChanged.enableTimeout(stationaryEnabled);
+        this.zStationaryChanged.enableTimeout(zStationaryEnabled);
         // this.tapChanged.enableTimeout(tapEnabled);
     }
 
@@ -97,6 +100,11 @@ public class HandStateEvents {
         this.stationaryChanged.set(value);
     }
 
+    public void setZStationary(Boolean stationary) {
+        int value = (stationary)?1:0;
+        this.zStationaryChanged.set(value);
+    }
+
     public void setTap(Boolean isTapping) {
         int value = (isTapping)?1:0;
         this.tapChanged.set(value);
@@ -106,12 +114,20 @@ public class HandStateEvents {
         return this.stationaryChanged.hasChanged();
     }
 
+    public Boolean zStationaryChanged() {
+        return this.zStationaryChanged.hasChanged();
+    }
+
     public Boolean tapChanged() {
         return this.tapChanged.hasChanged();
     }
 
     public String getStationaryString() {
         return (this.stationaryChanged.toInt() == 1)?"Stationary":"Moving";
+    }
+
+    public String getZStationaryString() {
+        return (this.zStationaryChanged.toInt() == 1)?"Stationary":"Moving";
     }
 
     public Boolean didTap() {
@@ -131,7 +147,7 @@ public class HandStateEvents {
     }
 
     public Boolean specialChanged() {
-        return (this.stationaryChanged.hasChanged() || this.tapChanged.hasChanged());
+        return (this.stationaryChanged.hasChanged() || this.zStationaryChanged.hasChanged() || this.tapChanged.hasChanged());
     }
 
     public List<String> getAnyChangeEvents() {

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -207,6 +207,10 @@ public class HandWaveyConfig {
             "stationaryChanged",
             defaultChangeTimeout,
             "Int (milliseconds): The amount of time that a change in whether the hand is stationary, or not, must be stable before it gets reported. You want a number that is small enough to not be noticed by a human. But large enough to catch errors that can cause random clicks/states.");
+        primaryHandTimeouts.newItem(
+            "zStationaryChanged",
+            defaultChangeTimeout,
+            "Int (milliseconds): The amount of time that a change in whether the hand is stationary on the z axis, or not, must be stable before it gets reported. You want a number that is small enough to not be noticed by a human. But large enough to catch errors that can cause random clicks/states.");
         // primaryHandTimeouts.newItem(
         //     "tapChanged",
         //     defaultChangeTimeout,
@@ -233,6 +237,10 @@ public class HandWaveyConfig {
             "stationaryChanged",
             defaultChangeTimeout,
             "Int (milliseconds): The amount of time that a change in whether the hand is stationary, or not, must be stable before it gets reported. You want a number that is small enough to not be noticed by a human. But large enough to catch errors that can cause random clicks/states.");
+        secondaryHandTimeouts.newItem(
+            "zStationaryChanged",
+            defaultChangeTimeout,
+            "Int (milliseconds): The amount of time that a change in whether the hand is stationary on the z axis, or not, must be stable before it gets reported. You want a number that is small enough to not be noticed by a human. But large enough to catch errors that can cause random clicks/states.");
         // secondaryHandTimeouts.newItem(
         //     "tapChanged",
         //     defaultChangeTimeout,
@@ -543,7 +551,7 @@ public class HandWaveyConfig {
             "When a new primary hand is introduced, the cursor and the ability to click the mouse or press keys, is disabled while the device stabilises.");
         actionEvents.newItem(
             "special-newHandUnfreezeCursor",
-            "recalibrateSegments();",
+            "recalibrateSegments();setSlot(\"250\", \"custom-recalibrateSegments\");",
             "When the time has expired for the Cursor freeze after a new primary hand is introduced.");
         actionEvents.newItem(
             "special-newHandUnfreezeEvent",
@@ -565,6 +573,22 @@ public class HandWaveyConfig {
             "special-secondaryStationary",
             "unlockGestures(\"secondary\");",
             "When the secondary hand starts moving.");
+        actionEvents.newItem(
+            "special-primaryZMoving",
+            "",
+            "When the primary hand starts moving on the z axis.");
+        actionEvents.newItem(
+            "special-primaryZStationary",
+            "setSlot(\"250\", \"custom-noop\");",
+            "When the primary hand starts moving on the z axis.");
+        actionEvents.newItem(
+            "special-secondaryZMoving",
+            "",
+            "When the secondary hand starts moving on the z axis.");
+        actionEvents.newItem(
+            "special-secondaryZStationary",
+            "",
+            "When the secondary hand starts moving on the z axis.");
         this.generateCustomConfig(actionEvents);
 
         Group audioConfig = this.config.newGroup("audioConfig");
@@ -773,5 +797,7 @@ public class HandWaveyConfig {
         customGroup.getItem("custom-delete").overrideDefault("keyDown(\"delete\");keyUp(\"delete\");"); // Press and release the delete key.
         customGroup.getItem("custom-ctrl+z").overrideDefault("keyDown(\"ctrl\");keyDown(\"z\");keyUp(\"z\");keyUp(\"ctrl\");"); // CTRL + z. Typically used for undo.
         customGroup.getItem("custom-ctrl+shift+z").overrideDefault("keyDown(\"ctrl\");keyDown(\"shift\");keyDown(\"z\");keyUp(\"z\");keyUp(\"shift\");keyUp(\"ctrl\");"); // CTRL + Shift z. Typically used for re-doing an undone task.
+
+        customGroup.getItem("custom-recalibrate").overrideDefault("setSlot(\"250\", \"custom-noop\");recalibrateSegments();"); // Recalibrate the segments once after entry.
     }
 }

--- a/src/main/java/handWavey/HandsState.java
+++ b/src/main/java/handWavey/HandsState.java
@@ -149,7 +149,8 @@ public class HandsState {
             Integer.parseInt(configGroupToLoad.getItem("OOBChanged").get()),
             Integer.parseInt(configGroupToLoad.getItem("segmentChanged").get()),
             Integer.parseInt(configGroupToLoad.getItem("stateChanged").get()),
-            Integer.parseInt(configGroupToLoad.getItem("stationaryChanged").get())
+            Integer.parseInt(configGroupToLoad.getItem("stationaryChanged").get()),
+            Integer.parseInt(configGroupToLoad.getItem("zStationaryChanged").get())
             );
     }
 
@@ -159,7 +160,8 @@ public class HandsState {
             enabled, // OOB
             enabled, // segment
             enabled, // state
-            enabled  // stationary
+            enabled, // stationary
+            enabled  // zStationary
             );
 
         String enabledString = "disabled";
@@ -236,6 +238,7 @@ public class HandsState {
             this.primaryState.setTap(this.cleanPrimary.isDoingATap(zone));
 
             this.primaryState.setStationary(this.cleanPrimary.isStationary());
+            this.primaryState.setZStationary(this.cleanPrimary.isZStationary());
         }
 
         if (this.handSummaries[1] == null || !this.handSummaries[1].isValid()) {
@@ -259,6 +262,7 @@ public class HandsState {
             this.secondaryState.setTap(this.cleanSecondary.isDoingATap(zone));
 
             this.secondaryState.setStationary(this.cleanSecondary.isStationary());
+            this.secondaryState.setZStationary(this.cleanSecondary.isZStationary());
         } else if (this.handSummaries[1] != null) {
             // TODO Is this branch needed?
             this.secondaryState.setState(this.cleanSecondary.getState());
@@ -274,6 +278,14 @@ public class HandsState {
                     this.debug.out(2, "Primary is \"" + stationaryState + "\" at speed " + String.valueOf(speed));
 
                     this.handWaveyEvent.triggerEvent("special-primary" + stationaryState);
+                }
+
+                if (this.primaryState.zStationaryChanged()) {
+                    String stationaryState = this.primaryState.getZStationaryString();
+
+                    this.debug.out(2, "Primary is \"z" + stationaryState + "\".");
+
+                    this.handWaveyEvent.triggerEvent("special-primaryZ" + stationaryState);
                 }
 
                 if (this.primaryState.tapChanged()) {
@@ -293,6 +305,15 @@ public class HandsState {
                     this.debug.out(2, "Secondary is \"" + stationaryState + "\" at speed " + String.valueOf(speed));
 
                     this.handWaveyEvent.triggerEvent("special-secondary" + stationaryState);
+                }
+
+                if (this.secondaryState.zStationaryChanged()) {
+                    String stationaryState = this.secondaryState.getZStationaryString();
+                    double speed = this.cleanSecondary.getSpeed();
+
+                    this.debug.out(2, "Secondary is \"" + stationaryState + "\".");
+
+                    this.handWaveyEvent.triggerEvent("special-secondaryZ" + stationaryState);
                 }
 
                 if (this.secondaryState.tapChanged()) {


### PR DESCRIPTION
## Background

Whenever a hand is newly introduced, the data from the leap motion controller is unstable.

To get around this I had various decisions relying on the data locked until the data stablised. But judging when this is was difficult:

* Analysing the data itself is full of assumptions that may not be correct for any given use-case.
* Waiting for a specific time period will either be too short, or too long, but never just right.

Instead I had it unlock (and later, also recalibrate) when the hand reached the active zone.  This worked well enough of the time that it's taken me this long to get around to doing it better.

## The change

The above remains in place.

I've added an additional re-calibrate when the hand stops moving along the z axis.

I was expecting to need to keep the lock going until then. But it seems to work well. I may revisit this.