### PR TITLE
Improve scroll exit

### DIFF
--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -536,8 +536,8 @@ public class HandWaveyConfig {
             "Maximum speed per second.");
         scrollConfig.newItem(
             "rewindScrollTime",
-            "200",
-            "int milliseconds. When we do a middle clicking motion while doing the scrolling gesture, it's easy to accidentally scroll. The idea of this setting is to get a position that is just before we started doing the gesture. The default should be pretty close for most people, but if you find that the scroll is still disrupted by the gesture, increase this number. If it rewinds to a time well before you began the gesture, then decrease this number.");
+            "100",
+            "int milliseconds. When exiting a scroll, it's easy to accidentally scroll. Often this is done simply from the leapmotion error. The idea of this setting is to get a position that is just before we started doing the gesture. The default should be pretty close for most people, but if you find that the scroll is still disrupted by the gesture, increase this number. If it rewinds to a time well before you began the gesture, then decrease this number.");
         scrollConfig.newItem(
             "historySize",
             "40",


### PR DESCRIPTION
The scroll rewind time was slightly too long, causing it to choose a time too far in the past to rewind to.

The result was that you had to hold your hand still for a period of time before releasing the scroll.