### PR TITLE
Consistent velocity/acceleration

### DIFF
--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -729,7 +729,7 @@ public class HandWaveyConfig {
             "The maximum change (in radians) that the auto-trim can apply in total. Setting this too small will limit how much auto-trim can help you. Setting it too large could lead to confusing behavior. The goal of auto-trim is to adjust to changes in the resting position of the hand so that segments still feel intuitive to the user despite the user not being consistent.");
         handCleaner.newItem(
             "stationarySpeed",
-            "15",
+            "18",
             "The speed, below which, the hand is considered stationary, and segment/state changes will be allowed. This is called speedLock. Setting this to -1 disables the speedLock. Change the debug level for HandsState to at least 2 to see the live speeds when the lock engages and disengages. You'll need stationarySpeed to be set to something positive for this to work. I suggest starting around 5-10.");
 
         Group tap = this.config.newGroup("tap");

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -482,7 +482,7 @@ public class HandWaveyConfig {
         Group touchPadConfig = this.config.newGroup("touchPad");
         touchPadConfig.newItem(
             "inputMultiplier",
-            "1",
+            "0.9",
             "Input is pretty small. Make it a bit bigger.");
         touchPadConfig.newItem(
             "outputMultiplier",

--- a/src/main/java/handWavey/HandWaveyManager.java
+++ b/src/main/java/handWavey/HandWaveyManager.java
@@ -284,11 +284,10 @@ public final class HandWaveyManager {
             this.handWaveyEvent.triggerAudioOnly("bug");
         }
 
-        this.handsState.setHandSummaries(handSummaries);
-
-        this.handSummaries = handSummaries;
-
-        this.handsState.figureOutStuff();
+        if (this.handsState.setHandSummaries(handSummaries)) {
+            this.handSummaries = handSummaries;
+            this.handsState.figureOutStuff();
+        }
 
         this.handWaveyEvent.triggerDelayedEvents();
 

--- a/src/main/java/handWavey/HandsState.java
+++ b/src/main/java/handWavey/HandsState.java
@@ -569,6 +569,7 @@ public class HandsState {
     }
 
     private Boolean frameIsActuallyNew(HandSummary[] newHS) {
+        if (newHS.length < 1) return false;
         if (newHS[0] == null) return false;
 
         double tolerance = 0.0000001;

--- a/src/main/java/handWavey/HandsState.java
+++ b/src/main/java/handWavey/HandsState.java
@@ -14,10 +14,12 @@ import debug.Debug;
 import java.util.HashMap;
 import java.util.List;
 import java.sql.Timestamp;
+import java.lang.Math;
 
 public class HandsState {
     private static HandsState handsState = null;
     private HandSummary[] handSummaries;
+    private double previousX = 0;
     private HandWaveyEvent handWaveyEvent;
 
     private Debug debug;
@@ -184,10 +186,17 @@ public class HandsState {
         this.handWaveyEvent = handWaveyEvent;
     }
 
+    public Boolean setHandSummaries(HandSummary[] handSummaries) {
+        Boolean result = true;
+        double tolerance = 0.00001;
 
-    public void setHandSummaries(HandSummary[] handSummaries) {
+        result = this.frameIsActuallyNew(handSummaries);
+
         this.handSummaries = handSummaries;
+
         notifyGotFrame();
+
+        return result;
     }
 
     public void figureOutStuff() {
@@ -547,6 +556,28 @@ public class HandsState {
 
     private long getNow() {
         return new Timestamp(System.currentTimeMillis()).getTime();
+    }
+
+    private Boolean withinTolerance(double value1, double value2, double tolerance) {
+        Boolean result = false;
+
+        double absDifference = Math.abs(value2 - value1);
+
+        // this.debug.out(0, "::: v1=" + String.valueOf(value1) + ", v2=" + String.valueOf(value2) + ", absDiff=" + String.valueOf(absDifference) + ", t=" + String.valueOf(tolerance));
+
+        return (absDifference < tolerance);
+    }
+
+    private Boolean frameIsActuallyNew(HandSummary[] newHS) {
+        if (newHS[0] == null) return false;
+
+        double tolerance = 0.0000001;
+
+        if (withinTolerance(newHS[0].getHandX(), this.previousX, tolerance)) return false;
+
+        this.previousX = newHS[0].getHandX();
+
+        return true;
     }
 
     public void notifyGotFrame() {

--- a/src/main/java/handWavey/HandsState.java
+++ b/src/main/java/handWavey/HandsState.java
@@ -570,8 +570,17 @@ public class HandsState {
     }
 
     private Boolean frameIsActuallyNew(HandSummary[] newHS) {
-        if (newHS.length < 1) return false;
-        if (newHS[0] == null) return false;
+        Boolean haveHands = false;
+        for (int i = 0; i < 10; i++) {
+            if (newHS[0] != null) {
+                haveHands = true;
+                break;
+            }
+        }
+
+        if (!haveHands) {
+            return true;
+        }
 
         double tolerance = 0.0000001;
 

--- a/src/main/java/handWavey/HandsState.java
+++ b/src/main/java/handWavey/HandsState.java
@@ -187,16 +187,17 @@ public class HandsState {
     }
 
     public Boolean setHandSummaries(HandSummary[] handSummaries) {
-        Boolean result = true;
+        Boolean handsAreNew = true;
         double tolerance = 0.00001;
 
-        result = this.frameIsActuallyNew(handSummaries);
-
+        handsAreNew = this.frameIsActuallyNew(handSummaries);
         this.handSummaries = handSummaries;
 
-        notifyGotFrame();
+        if (handsAreNew) {
+            notifyGotFrame();
+        }
 
-        return result;
+        return handsAreNew;
     }
 
     public void figureOutStuff() {


### PR DESCRIPTION
It would be easy to under-sell this. This bug has been the most annoying bug in handWavey... Probably ever.

## The bug

When a resource was constrained, and the LeapMotion controller was not able to get a new frame processed in to meet the frame rate, it would just duplicate the previous frame. This meant that the deltas were normally consistent, and then when this would happen, the frame would have 0 change from the previous frame, and the next frame would make up the difference.

This may be fine in systems that use absolute positioning, but relative positioning with velocity and acceleration calculations, This had the effect of:

Normal, Normal, Normal, Normal, Nothing, ZOOM.

## The solution

I've added a very primitive check to test for whether the frame has changed at all from the previous one.

I spent a few days testing and refining this while I figured out exactly how I wanted handWavey to behave in this situation.
