### PR TITLE
Fix jumpy cursor

### DIFF
--- a/docs/user/howTo/jumpyPointer.md
+++ b/docs/user/howTo/jumpyPointer.md
@@ -1,0 +1,71 @@
+# Jumpy cursor movement
+
+If the mouse cursor is jumping around in weird ways, this is the document to solve that.
+
+## Sudden large jumps while moving slowly
+
+### The exact problem
+
+Cursor movement is mostly consistent. Then occasionally (a few times a minute), the cursor jumps by a large amount, and then continues moving like it did before as if nothing weird had happened.
+
+### Why
+
+Each frame that comes in is marked with a timestamp for when it came in. Sometimes a frame is delayed, causing it to have a timestamp that is very close to the previous frame. This causes a divide by 0/(or very small number) when calculating the speed.
+
+### Solution
+
+Use the `minFrameGapSeconds` setting in dataCleaning.yml in the [config directory](https://github.com/ksandom/handWavey/blob/main/docs/user/configuration/whereIsMyConfigurationDirectory.md).
+
+`minFrameGapSeconds` defines the minimum gap between frames in seconds. When the gap is smaller than this number, a debug message will be produced like
+
+```
+Debug 1 (Motion): Skipping frame that is only 0.001 seconds old.
+```
+
+and the frame will not contribute to the cursor moving.
+
+* If this number is too high, then too many frames will get skipped, and the cursor won't move as much as desired.
+* If this number is too low, then pointer acceleration can be erratic when frame timings get erratic (Common during high CPU load.)
+
+## Cursor barely moves regardless of input
+
+### The exact problem
+
+The cursor occasionally moves, but most of the time it doesn't, despite what the hand is doing.
+
+You will see lots of these in the debug output:
+
+```
+Debug 1 (Motion): Skipping frame that is only 0.001 seconds old.
+```
+
+### Why
+
+The value is set too high.
+
+### Solution
+
+Make the value lower. You'll get a feel for what the value should be by looking at the some of these messages:
+
+```
+Debug 1 (Motion): Skipping frame that is only 0.001 seconds old.
+```
+
+You want the value to be lower than most of the messages. But if it's too low, it won't catch the frames that are too close together.
+
+Have a play with the number until you get it right.
+
+## Pointer acceleration does not behave as your want it to
+
+### The exact problem
+
+Movement is relatively consistent/smooth. It's just not quite as you want it to be.
+
+### Why
+
+It's probably not configured to your liking.
+
+### Solution
+
+Take a look at the [sensitivity](https://github.com/ksandom/handWavey/blob/main/docs/user/configuration/sensitivity.md) documentation.
+

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -161,6 +161,10 @@ public class HandWaveyConfig {
             "maxChange",
             "100",
             "If the difference between the current input position and the previous input position is larger than this number, ignore it, and reset the state so that subsequent input makes sense. This is usually caused by going OOB on one side of the usable cone, and re-entering on the other side of the cone. When this number is too high, errors can slip through that cause the mouse cursor to jump. When it's too low, the cursor will regularly stop when you move your hand too fast. This symptom should not be confused with a hang due to something like garbage collection.");
+        dataCleaning.newItem(
+            "minFrameGapSeconds",
+            "0.002",
+            "The minimum gap between frames in seconds. When the gap is smaller than this number, a debug message will be produced like \"Skipping frame that is only 0.001 seconds old.\", and the frame will not contribute to the cursor moving. If this number is too high, then too many frames will get skipped, and the cursor won't move as much as desired. If this number is too low, then pointer acceleration can be erratic when frame timings get erratic (Common during high CPU load.)");
 
         Group newHands = dataCleaning.newGroup("newHands");
         newHands.newItem(

--- a/src/main/java/handWavey/HandsState.java
+++ b/src/main/java/handWavey/HandsState.java
@@ -619,6 +619,7 @@ public class HandsState {
 
         // We really don't need to track anything that long.
         if (this.previousFrameAge > this.sillyFrameAge) {
+            this.debug.out(0, "previousFrameAge was too big (" + String.valueOf(this.previousFrameAge) + "). Setting it to " + String.valueOf(this.sillyFrameAge) + ".");
             this.previousFrameAge = this.sillyFrameAge;
         }
     }


### PR DESCRIPTION
This was a really annoying bug where the cursor would randomly jump by about 400 pixels and then continue as if nothing had happened.

It was caused by the occasional frame being delayed, and then it coming in with another frame, causing them to have a tiny time gap between them. This caused the speed calculation to divide by a very small number, which caused huge acceleration.

This bug has probably been present since the beginning, but it was only noticeable now that the calculations are much more precise and reliant on the time.