### PR TITLE
Move jump cursor fix to be globally applied

### DIFF
--- a/src/main/java/handWavey/Motion.java
+++ b/src/main/java/handWavey/Motion.java
@@ -72,8 +72,6 @@ public final class Motion {
     private double relativeSensitivity = 0.1;
 
     private int maxChange = 200;
-    private double minFrameGapSeconds = 0.002;
-    private double frameTimeOverflow = 0;
 
     private String zoneMode = "touchScreen";
 
@@ -106,9 +104,6 @@ public final class Motion {
         // Set up maxChange.
         Group dataCleaning = Config.singleton().getGroup("dataCleaning");
         this.maxChange = Integer.parseInt(dataCleaning.getItem("maxChange").get());
-
-        // Set up minFrameGapSeconds.
-        this.minFrameGapSeconds = Double.parseDouble(dataCleaning.getItem("minFrameGapSeconds").get());
 
         // Get configured multipliers.
         Group axisOrientation = Config.singleton().getGroup("axisOrientation");
@@ -374,16 +369,6 @@ public final class Motion {
 
         // Calculate time since the last frame.
         double frameDurationSeconds = this.handsState.getPreviousFrameAge() / 1000.0;
-
-        if (frameDurationSeconds < minFrameGapSeconds) {
-            this.debug.out(1, "Skipping frame with only " + String.valueOf(frameDurationSeconds) + " seconds gap from the previous frame.");
-
-            this.frameTimeOverflow = frameDurationSeconds;
-            return;
-        } else {
-            frameDurationSeconds += this.frameTimeOverflow;
-            this.frameTimeOverflow = 0;
-        }
 
         // Handle accumulated movement.
         if (!this.shouldDiscardOldPosition) {


### PR DESCRIPTION
There are a few things that use speed/acceleration data. Applying the fix globally means that they all become more reliable. And it removes some unnecessary processing time.