### PR TITLE
Reduce the default debugging for MacroCore

### DIFF
--- a/src/main/java/macro/MacroCore.java
+++ b/src/main/java/macro/MacroCore.java
@@ -239,7 +239,7 @@ public class MacroCore {
 
         this.increaseNesting();
         String prefix = nestedDebugPrefix(this.nestingLevel);
-        this.debug.out(1, prefix + command + ": " + macro);
+        this.debug.out(2, prefix + command + ": " + macro);
         macroLine.runLine(macro);
         this.decreaseNesting();
 
@@ -263,9 +263,9 @@ public class MacroCore {
         this.increaseNesting();
         String[] parameters = separateParameters("");
         if (!doInternalInstruction(commandToTry, parameters)) {
-            this.debug.out(1, "Internal instruction \"" + commandToTry + "\" does not exist.");
+            this.debug.out(2, "Internal instruction \"" + commandToTry + "\" does not exist.");
             if (!this.tryMacro(commandToTry)) {
-                this.debug.out(1, "Macro \"" + commandToTry + "\" does not exist.");
+                this.debug.out(2, "Macro \"" + commandToTry + "\" does not exist.");
                 if (!this.events.itemExists(commandToTry)) {
                     this.debug.out(0, commandToTry + " doesn't appear to be a macro or event.");
                 } else {


### PR DESCRIPTION
A lot of the output from MacroLine isn't needed by users under normal circumstances, but it is good to have it when trying to untangle why something isn't working. I've moved it to debug level 2.