### PR TITLE
Add lock debugging

### DIFF
--- a/docs/user/reference/macroCommands.md
+++ b/docs/user/reference/macroCommands.md
@@ -418,6 +418,22 @@ Will unlock the primary hand.
 
 The counterpart is `lockTaps();`.
 
+#### showTapLocks
+
+`showTapLocks();` shows the current state of tap locks. Eg
+
+```
+Debug 1 (HandCleaner): Primary taps are locked with no timeout.
+Debug 1 (HandCleaner): Secondary taps are not locked locked.
+```
+
+or
+
+```
+Debug 1 (HandCleaner): Primary taps are locked for another 150 milliseconds (1709562338165-1709562338015).
+Debug 1 (HandCleaner): Primary gestures are locked.
+```
+
 #### lockGestures
 
 `lockGestures("hand");` locks roll and open/closed state changes, effectively locking most gestures that can be performed.
@@ -489,6 +505,33 @@ unlockGestures();
 Will unlock gestures on the primary hand.
 
 The counterpart is `lockGestures();`
+
+#### showGestureLocks
+
+`showGestureLocks();` shows the current state of gesture locks. Eg
+
+```
+Debug 1 (HandCleaner): Secondary gestures are not locked.
+Debug 1 (HandCleaner): Primary taps are not locked locked.
+```
+
+or
+
+```
+Debug 1 (HandCleaner): Primary gestures are locked.
+Debug 1 (HandCleaner): Primary taps are locked with no timeout.
+```
+
+#### showLocks
+
+`showLocks();` shows the state of all locks. At the time of this writing, that is `showTapLocks();` and `showGestureLocks();`, but will likely show other kinds of locks in the future. This currently looks like this:
+
+```
+Debug 1 (HandCleaner): Primary taps are locked with no timeout.
+Debug 1 (HandCleaner): Secondary taps are not locked locked.
+Debug 1 (HandCleaner): Primary gestures are locked.
+Debug 1 (HandCleaner): Secondary gestures are not locked.
+```
 
 ## Default macros
 

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -121,6 +121,10 @@ public class HandWaveyConfig {
             "1",
             "Int: Sensible numbers are 0-5, where 0 is no debugging, and 5 is probably more detail than you'll ever want. HandsState tracks what gesture the hands are currently making, and triggers events based on changes.");
         debug.newItem(
+            "HandCleaner",
+            "1",
+            "Int: Sensible numbers are 0-5, where 0 is no debugging, and 5 is probably more detail than you'll ever want. HandCleaner is responsible for filtering out noise in the data that handWavey receives.");
+        debug.newItem(
             "Motion",
             "1",
             "Int: Sensible numbers are 0-5, where 0 is no debugging, and 5 is probably more detail than you'll ever want. Motion takes hand movements and converts them into output movements like moving the mouse cursor, or scrolling.");
@@ -845,7 +849,7 @@ public class HandWaveyConfig {
 
         macrosGroup.newItem(
             "noHands",
-            "cancelAllDelayedDos();setButton(\"left\");releaseButtons();releaseKeys();releaseZone();unlockTaps(\"primary\");",
+            "showLocks();cancelAllDelayedDos();setButton(\"left\");releaseButtons();releaseKeys();releaseZone();unlockTaps(\"primary\");",
             "To be triggered when the primary hand is no longer present.");
 
         macrosGroup.newItem(

--- a/src/main/java/handWavey/HandWaveyManager.java
+++ b/src/main/java/handWavey/HandWaveyManager.java
@@ -272,12 +272,24 @@ public final class HandWaveyManager {
         handsState.unlockGestures(hand);
     }
 
+    public void showGestureLocks() {
+        handsState.showGestureLocks();
+    }
+
     public void lockTaps(String hand, long time) {
         handsState.lockTaps(hand, time);
     }
 
     public void unlockTaps(String hand, long time) {
         handsState.unlockTaps(hand, time);
+    }
+
+    public void showTapLocks() {
+        handsState.showTapLocks();
+    }
+
+    public void showLocks() {
+        handsState.showLocks();
     }
 
 

--- a/src/main/java/handWavey/HandsState.java
+++ b/src/main/java/handWavey/HandsState.java
@@ -27,8 +27,8 @@ public class HandsState {
     private HandStateEvents primaryState = new HandStateEvents(true);
     private HandStateEvents secondaryState = new HandStateEvents(false);
 
-    private HandCleaner cleanPrimary = new HandCleaner();
-    private HandCleaner cleanSecondary = new HandCleaner();
+    private HandCleaner cleanPrimary = new HandCleaner("Primary");
+    private HandCleaner cleanSecondary = new HandCleaner("Secondary");
 
     private double zNoMoveBegin = 0;
     private double zActiveBegin = 0;
@@ -669,6 +669,12 @@ public class HandsState {
         }
     }
 
+    public void showGestureLocks() {
+        this.cleanPrimary.showGestureLocks();
+        this.cleanSecondary.showGestureLocks();
+    }
+
+
     public void lockTaps(String hand, long time) {
         if (!hand.equals("secondary")) {
             this.cleanPrimary.setTapLock(true, time);
@@ -683,6 +689,16 @@ public class HandsState {
         } else {
             this.cleanSecondary.setTapLock(false, time);
         }
+    }
+
+    public void showTapLocks() {
+        this.cleanPrimary.showTapLocks();
+        this.cleanSecondary.showTapLocks();
+    }
+
+    public void showLocks() {
+        this.showTapLocks();
+        this.showGestureLocks();
     }
 }
 

--- a/src/main/java/macro/MacroCore.java
+++ b/src/main/java/macro/MacroCore.java
@@ -202,11 +202,20 @@ public class MacroCore {
             case "unlockGestures":
                 this.handWaveyManager.unlockGestures(parm(parameters, 0, "primary"));
                 break;
+            case "showGestureLocks":
+                this.handWaveyManager.showGestureLocks();
+                break;
             case "lockTaps":
                 this.handWaveyManager.lockTaps(parm(parameters, 0, "primary"), Long.parseLong(parm(parameters, 1, "0")));
                 break;
             case "unlockTaps":
                 this.handWaveyManager.unlockTaps(parm(parameters, 0, "primary"), Long.parseLong(parm(parameters, 1, "0")));
+                break;
+            case "showTapLocks":
+                this.handWaveyManager.showTapLocks();
+                break;
+            case "showLocks":
+                this.handWaveyManager.showLocks();
                 break;
 
 

--- a/src/test/java/handWavey/TestHandCleaner.java
+++ b/src/test/java/handWavey/TestHandCleaner.java
@@ -20,7 +20,7 @@ class TestHandCleaner {
         this.handWaveyConfig = new HandWaveyConfig("unitTest");
         this.handWaveyConfig.defineGeneralConfig();
 
-        this.handCleaner = new HandCleaner();
+        this.handCleaner = new HandCleaner("UnitTest");
 
         this.handSummary = new HandSummary(42);
         this.handSummary.setHandPosition(10, 200, 20);


### PR DESCRIPTION
Show the state of tap and gesture locks from time to time.

This is useful for debugging when a lock isn't being unlocked when it is no longer needed.