### PR TITLE
Fix slingshotting from one gesture to another

### DIFF
--- a/examples/gestureLayouts/tiltClick/actionModifier/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/actionModifier/actionEvents.yml
@@ -24,12 +24,6 @@ items:
     value: debug("0", "Toolset = Multi-click.");
   individual-pAction9Closed-enter:
     value: toolset-multiClick();
-  general-segment-p0-enter:
-    value: ""
-  general-segment-p2-enter:
-    value: ""
-  general-segment-p2-exit:
-    value: ""
   general-segment-s0-enter:
     value: keyDown("ctrl");
   general-segment-s0-exit:

--- a/examples/gestureLayouts/tiltClick/closeDoubleClick/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/closeDoubleClick/actionEvents.yml
@@ -2,12 +2,6 @@ groups: {}
 items:
   general-zone-pAction-enter:
     value: do-mDoubleClick-left();
-  general-segment-p0-enter:
-    value: ""
-  general-segment-p2-enter:
-    value: ""
-  general-segment-p2-exit:
-    value: ""
   general-segment-s0-enter:
     value: keyDown("ctrl");
   general-segment-s0-exit:

--- a/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
@@ -2,12 +2,6 @@ groups: {}
 items:
   general-zone-pAction-enter:
     value: do-mDoubleClick-left();
-  general-segment-p0-enter:
-    value: ""
-  general-segment-p2-enter:
-    value: ""
-  general-segment-p2-exit:
-    value: ""
   general-segment-s0-enter:
     value: keyDown("ctrl");
   general-segment-s0-exit:

--- a/examples/gestureLayouts/tiltClick/zoom/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/zoom/actionEvents.yml
@@ -2,12 +2,6 @@ groups: {}
 items:
   general-zone-pAction-enter:
     value: do-mDoubleClick-left();
-  general-segment-p0-enter:
-    value: ""
-  general-segment-p2-enter:
-    value: ""
-  general-segment-p2-exit:
-    value: ""
   general-segment-s0-enter:
     value: keyDown("ctrl");
   general-segment-s0-exit:

--- a/src/main/java/handWavey/Gesture.java
+++ b/src/main/java/handWavey/Gesture.java
@@ -96,19 +96,19 @@ public class Gesture {
 
         // Set buttons.
         overrideDefault(
-            "general-segment-p0-enter",
+            "individual-pNonOOB0Open-enter",
             "unlockTaps(\"primary\", \"150\");setButton(\"left\");",
             "");
         overrideDefault(
-            "general-segment-p1-enter",
+            "individual-pNonOOB1Open-enter",
             "lockTaps(\"primary\");unlockTaps(\"primary\", \"150\");setButton(\"right\");",
             "");
         overrideDefault(
-            "general-segment-p2-enter",
+            "individual-pNonOOB2Open-enter",
             "setButton(\"middle\");overrideZone(\"scroll\");lockTaps(\"primary\");unlockTaps(\"primary\", \"150\");",
             "");
         overrideDefault(
-            "general-segment-p2-exit",
+            "individual-pNonOOB2Open-enter",
             "releaseZone();unlockTaps(\"primary\");",
             "");
 
@@ -146,6 +146,10 @@ public class Gesture {
         overrideDefault(
             "general-segment-pAnyChange",
             "stabliseSegment();",
+            "");
+        overrideDefault(
+            "general-segment-p0-enter",
+            "stabliseNeutralPosition();",
             "");
         overrideDefault(
             "special-newHandUnfreezeEvent",

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -908,6 +908,21 @@ public class HandWaveyConfig {
             "Reduce noise caused by the hand rotating.");
 
         macrosGroup.newItem(
+            "stabliseNeutralPosition",
+            "lockGestures(\"primary\");delayedDo(\"continue-stabliseNeutralPosition\", \"100\");",
+            "When coming out of a gesture, it's easy to accidentally slingshot into another gesture. This is to prevent that, and is intended to be called when entering segment 0.");
+
+        macrosGroup.newItem(
+            "continue-stabliseNeutralPosition",
+            "unlockGestures(\"primary\");recalibrateSegments();cancelAllDelayedDos();delayedDo(\"finish-stabliseNeutralPosition\", \"60\");",
+            "Part to of preventing slingshotting.");
+
+        macrosGroup.newItem(
+            "finish-stabliseNeutralPosition",
+            "recalibrateSegments();cancelAllDelayedDos();",
+            "The final part of slingshot prevention.");
+
+        macrosGroup.newItem(
             "yankScroll-enter",
             "cancelAllDelayedDos();lockCursor();allowWheelClicks();setSlot(\"3\", \"do-scroll\");lockTaps(\"primary\");unlockTaps(\"primary\" , \"800\");delayedDo(\"do-earlyScroll\", \"900\");delayedDo(\"do-scroll\", \"1500\");",
             "Yank scrolling is the grab to scroll, where you need to yank it to get it started. The -enter macro gets it set up.");


### PR DESCRIPTION
When performing a tilt gesture, it was very easy to accidentally perform another tilt gesture when exiting the first gesture.

This PR fixes that by

* Recalibrating the neutral position soon after re-entering the neutral position.
* Disabling gestures for a few milliseconds after re-entering the neutral position.