### PR TITLE
Make tapping more responsive

### DIFF
--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -714,7 +714,7 @@ public class HandWaveyConfig {
             "The moving mean length for the Y axis. >0. 1 effectively disables the moving mean. A larger number is more effective at removing noise, at the expense of responsiveness.");
         handCleaner.newItem(
             "movingMeanZ",
-            "4",
+            "1",
             "The moving mean length for the Z axis. >0. 1 effectively disables the moving mean. A larger number is more effective at removing noise, at the expense of responsiveness.");
         handCleaner.newItem(
             "movingMeanRoll",


### PR DESCRIPTION
The movingmean was needed in the early days, but is making error persist now, which leads to false positives.

This PR effectively disables the moving mean on the z axis, which makes the tapping more responsive, and allows the logic to filter out more false positives.