### PR TITLE
Tap consistency

### DIFF
--- a/docs/user/configuration/tap.md
+++ b/docs/user/configuration/tap.md
@@ -20,16 +20,37 @@ The motivation for this is to
 
 ### Tuning
 
+        tap.newItem(
+            "tapMinTime",
+            "50",
+            "The minimum time that the tap must take.");
+        tap.newItem(
+            "tapMaxTime",
+            "100",
+            "The maximum time that the tap can take.");
+        tap.newItem(
+            "postTapTime",
+            "100",
+            "The minimum amount of time that the hand must not be moving more than tapSpeed after performing the tap.");
+
+
+
 * tap.yml
     * `tapSpeed` - How fast your hand needs to move to trigger the tap event.
-        * Setting this too low leads to unwanted tap events.
-        * Setting this too high makes it very hard to trigger a tap event.
-    * `samplesToWaitNegative` - How many retraction samples to wait until you can trigger another tap event after the last successful one completed.
-        * Setting this too small leads to unwanted tap events.
-        * Setting this too large restricts your ability to tap multiple things in a short space of time.
-    * `samplesToWaitPositive` - After `samplesToWaitNegative` has succeeded, How many samples going deeper to wait until you can trigger another tap event after the last successful one completed.
-        * Setting this too small leads to unwanted tap events.
-        * Setting this too large restricts your ability to tap multiple things in a short space of time.
+        * Too low:
+            * can lead to unwanted tap events.
+            * it can also lead to `isZStationary()` fluctuating and no taps can be performed.
+        * Too high: makes it very hard to trigger a tap event.
+        * Try starting with a setting around 5-10.
+    * `tapMinTime` - The minimum amount of milliseconds that you must be moving your hand in the Z direction bove the `tapSpeed` value to be counted as a tap motion.
+        * Too low: will make it too easy to trigger a tap event.
+        * Too high: will make you have to move your hand over a long distance to perform a tap.
+    * `tapMaxTime` - The maximum amount of milliseconds. If your hand is still moving after this time, it isn't a tap, and it will be discarded.
+        * Too low will cause legitimate taps to be discarded because they took a little too long.
+        * Too high: will allow some non-legitimate movements to count as taps.
+    * `postTapTime` - How long (in milliseconds) your hand must be relatively stationary on the Z axis to be counted as a tap. If you move away too quickly, it will be assumed that it is part of another action.
+        * Too low: It will be easy to trigger accidental taps.
+        * Too high: You will have to concentrate to keep your hand steady after performing a tap.
 * click.yaml
     * `rewindCursorTime` - Use the cursor position from this much time before the tap event was triggered.
         * Setting this too low will make the effective click location move with the noise created during the tap.

--- a/src/main/java/dataCleaner/Consistently.java
+++ b/src/main/java/dataCleaner/Consistently.java
@@ -1,0 +1,101 @@
+// (c) 2023 Kevin Sandom under the GPL v3. See LICENSE for details.
+
+/*
+Tracks whether a boolean value has consistently been an expected value within a specified time range.
+
+It can provide:
+* Has it been consistently the expected value yet?
+*/
+
+package dataCleaner;
+
+// import debug.Debug;
+import java.util.Date;
+
+public class Consistently {
+    Boolean initialised = false;
+
+    String name = "Unnamed";
+
+    Boolean expectedValue = false;
+    long minMilliseconds = 0;
+    Boolean useMax = false;
+    long maxMilliseconds = 0;
+
+    long firstMatchingTick = 0;
+
+    long overrideTime = 0;
+
+    public Consistently(Boolean expectedValue, long minMilliseconds, String name) {
+        this.expectedValue = expectedValue;
+        this.minMilliseconds = minMilliseconds;
+        this.name = name;
+    }
+
+    // If an upper limit is wanted. This is where to set it.
+    public void setMax(long maxMilliseconds) {
+        this.maxMilliseconds = maxMilliseconds;
+        this.useMax = true;
+    }
+
+    // To be called every time we have new data.
+    public void tick(Boolean value) {
+        if (value == this.expectedValue) {
+            if (this.firstMatchingTick == 0) {
+                this.firstMatchingTick = timeInMilliseconds();
+            }
+        } else {
+            reset();
+        }
+
+        this.initialised = true;
+    }
+
+    // Does the current state match our criteria?
+    // Note that we don't need to call this to track anything. All of that is done with tick. So we only need to call this when we want to know something.
+    public Boolean isConsistent() {
+        if (!this.initialised) {
+            return false;
+        }
+
+        if (this.firstMatchingTick == 0) { // TODO check this.
+            return false;
+        }
+
+        long now = timeInMilliseconds();
+        long duration = now - this.firstMatchingTick;
+
+        if (duration < this.minMilliseconds) {
+            return false;
+        }
+
+        if (this.useMax) {
+            if (duration > this.maxMilliseconds) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // Regardless of whether we match, stop it so that the next tick starts from scratch.
+    public void reset() {
+        this.firstMatchingTick = 0;
+    }
+
+    // Get the current time in milliseconds.
+    private long timeInMilliseconds() {
+        if (this.overrideTime != 0) {
+            return this.overrideTime;
+        }
+
+        Date date = new Date();
+        return date.getTime();
+    }
+
+    // This is purely for unit testing.
+    public void overrideTime(long overrideTime) {
+        this.overrideTime = overrideTime;
+    }
+
+}

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -748,16 +748,20 @@ public class HandWaveyConfig {
         Group tap = this.config.newGroup("tap");
         tap.newItem(
             "tapSpeed",
-            "10",
+            "5",
             "The speed of the Z axis (away from you), above which, the hand is considered to be performing a tap. Setting this to -1 disables the tap gesture. You'll need tapSpeed to be set to something positive for this to work. I suggest starting around 5-10.");
         tap.newItem(
-            "samplesToWaitNegative",
-            "1",
-            "Number of samples in the negative direction to wait until allowing another tap.");
+            "tapMinTime",
+            "50",
+            "The minimum time that the tap must take.");
         tap.newItem(
-            "samplesToWaitPositive",
-            "5",
-            "Number of samples in the positive direction to wait until allowing a tap.");
+            "tapMaxTime",
+            "100",
+            "The maximum time that the tap can take.");
+        tap.newItem(
+            "postTapTime",
+            "100",
+            "The minimum amount of time that the hand must not be moving more than tapSpeed after performing the tap.");
 
         Group macros = this.config.newGroup("macros");
         generateMacroConfig(macros);

--- a/src/test/java/dataCleaner/TestConsistently.java
+++ b/src/test/java/dataCleaner/TestConsistently.java
@@ -1,0 +1,94 @@
+// (c) 2022 Kevin Sandom under the GPL v3. See LICENSE for details.
+
+package dataCleaner;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.*;
+
+import dataCleaner.Consistently;
+
+class TestConsistently {
+    Consistently consistentlySomething = null;
+
+    @BeforeEach
+    void setUp() {
+        this.consistentlySomething = new Consistently(true, 100, "Unit test");
+        this.consistentlySomething.overrideTime(1000);
+    }
+
+    @AfterEach
+    void destroy() {
+        this.consistentlySomething = null;
+    }
+
+    @Test
+    public void testBasicMin() {
+         // Set up the initial state.
+         this.consistentlySomething.tick(true);
+
+         // Test true, but not enough time passed.
+         this.consistentlySomething.overrideTime(1010);
+         this.consistentlySomething.tick(true);
+         assertEquals(false, this.consistentlySomething.isConsistent());
+
+         // Test true, and enough time passed.
+         this.consistentlySomething.overrideTime(1110);
+         this.consistentlySomething.tick(true);
+         assertEquals(true, this.consistentlySomething.isConsistent());
+
+         // Test still true after more time.
+         this.consistentlySomething.overrideTime(2000);
+         this.consistentlySomething.tick(true);
+         assertEquals(true, this.consistentlySomething.isConsistent());
+    }
+
+    @Test
+    public void testMinMax() {
+         // Set up the initial state.
+         this.consistentlySomething.tick(true);
+         this.consistentlySomething.setMax(200);
+
+         // Test true, but not enough time passed.
+         this.consistentlySomething.overrideTime(1010);
+         this.consistentlySomething.tick(true);
+         assertEquals(false, this.consistentlySomething.isConsistent());
+
+         // Test true, and enough time passed.
+         this.consistentlySomething.overrideTime(1110);
+         this.consistentlySomething.tick(true);
+         assertEquals(true, this.consistentlySomething.isConsistent());
+
+         // Test true, and enough time passed.
+         this.consistentlySomething.overrideTime(2000);
+         this.consistentlySomething.tick(true);
+         assertEquals(false, this.consistentlySomething.isConsistent());
+    }
+
+    @Test
+    public void testBroken() {
+         // Set up the initial state.
+         this.consistentlySomething.tick(true);
+
+         // Test true, but not enough time passed.
+         this.consistentlySomething.overrideTime(1010);
+         this.consistentlySomething.tick(true);
+         assertEquals(false, this.consistentlySomething.isConsistent());
+
+         // Test false, and enough time passed.
+         this.consistentlySomething.overrideTime(1110);
+         this.consistentlySomething.tick(false);
+         assertEquals(false, this.consistentlySomething.isConsistent());
+
+         // Test true, not enough time.
+         this.consistentlySomething.overrideTime(1120);
+         this.consistentlySomething.tick(true);
+         assertEquals(false, this.consistentlySomething.isConsistent());
+
+         // Test true, enough time.
+         this.consistentlySomething.overrideTime(1220);
+         this.consistentlySomething.tick(true);
+         assertEquals(true, this.consistentlySomething.isConsistent());
+    }
+}

--- a/src/test/java/handWavey/TestGesture.java
+++ b/src/test/java/handWavey/TestGesture.java
@@ -73,7 +73,7 @@ class TestGesture {
 
         // A specific change in a single component.
         assertEquals("", actionEvents.getItem("general-zone-pActive-enter").get());
-        assertEquals("unlockTaps(\"primary\", \"150\");setButton(\"left\");", actionEvents.getItem("general-segment-p0-enter").get());
+        assertEquals("stabliseNeutralPosition();", actionEvents.getItem("general-segment-p0-enter").get());
         assertEquals("", actionEvents.getItem("general-state-pOpen-enter").get());
         assertEquals("", actionEvents.getItem("general-zone-sActive-enter").get());
         assertEquals("keyDown(\"ctrl\");", actionEvents.getItem("general-segment-s0-enter").get());

--- a/src/test/java/handWavey/TestHandCleaner.java
+++ b/src/test/java/handWavey/TestHandCleaner.java
@@ -93,7 +93,7 @@ class TestHandCleaner {
 
         assertEquals(this.handCleaner.getHandX(), 7.5);
         assertEquals(this.handCleaner.getHandY(), 150);
-        assertEquals(this.handCleaner.getHandZ(), 15);
+        assertEquals(this.handCleaner.getHandZ(), 0);
         assertEquals(this.handCleaner.getHandRoll(), 0.075, 0.001);
         assertEquals(this.handCleaner.getHandPitch(), 0);
         assertEquals(this.handCleaner.getHandYaw(), -0.075, 0.001);


### PR DESCRIPTION
## Background

Trying to find a balance between accidental taps, and taps not being sensitive enough, has been frustrating.

Previously, the main mechanism for proceeding through the tap logic was counting frames in each direction. When the framerate fluctuated, assumptions would break.

## Solution

Now it's time based, and there's a little more to it. Yet a lot of the original logic was no longer needed. So it's actually simpler to read now.

Over the next while, I'll make tweaks to the default configuration as I continue to find what is most comfortable to use. After that, I'll create, and potentially remove, [some examples](https://github.com/ksandom/handWavey/tree/main/examples/tap).