### PR TITLE
Add abstract audio actions

### DIFF
--- a/examples/audio/default/README.md
+++ b/examples/audio/default/README.md
@@ -1,16 +1,3 @@
 # Default audio config
 
-This is the basic config that will tell you about basic changes that are happening. This is currently the default.
-
-## Notifications
-
-### General
-
-* Primary
-    * Zone.
-    * Segment.
-    * State (open/close/absent).
-* Secondary
-    * Zone.
-    * Segment.
-    * State (open/close/absent).
+This is the default configuration that will tell you about actions that you are performing, using the same notifications regardless of which gestureLayout you're using.

--- a/examples/audio/default/audioEvents.yml
+++ b/examples/audio/default/audioEvents.yml
@@ -1,26 +1,72 @@
 groups: {}
 items:
-  general-state-pClosed-enter:
-    value: metalDing07.wav
-  special-newHandFreeze:
+  general-zone-pActive-enter:
+    value: piano-short-C3.wav
+  abstract-scroll-begin:
     value: ''
-  general-segment-sAnyChange:
-    value: metalDing04.wav
+  abstract-mMiddle-down:
+    value: piano-short-F3.wav
+  individual-pNonOOB1Open-enter:
+    value: ''
+  abstract-mRight-up:
+    value: piano-short-A3.wav
   general-zone-pAction-enter:
-    value: metalDing07.wav
-  general-zone-pAnyChange:
-    value: metalDing01.wav
-  general-state-pClosed-exit:
-    value: metalDing08.wav
-  general-zone-sAnyChange:
-    value: metalDing03.wav
-  general-segment-pAnyChange:
-    value: metalDing02.wav
-  imposterHand-replace:
-    value: ''
+    value: piano-short-C4.wav
   special-newHandUnfreezeEvent:
     value: ''
-  special-newHandUnfreezeCursor:
+  imposterHand-replace:
     value: ''
+  abstract-doubleClick:
+    value: metalDing01.wav
+  special-newHandUnfreezeCursor:
+    value: recalibrateSegments();
+  abstract-mMiddle-click:
+    value: piano-short-B4.wav
+  abstract-mLeft-click:
+    value: piano-short-G4.wav
+  special-secondaryStationary:
+    value: ''
+  special-newHandFreeze:
+    value: ''
+  abstract-mRight-click:
+    value: piano-short-A4.wav
+  general-zone-sAnyChange:
+    value: metalDing03.wav
+  general-zone-pNoMove-enter:
+    value: piano-short-C2.wav
   imposterHand-discard:
+    value: ''
+  individual-pNonOOB2Open-enter:
+    value: ''
+  abstract-mRight-down:
+    value: piano-short-F3.wav
+  abstract-mMiddle-up:
+    value: piano-short-B3.wav
+  general-segment-sAnyChange:
+    value: metalDing04.wav
+  general-state-pClosed-exit:
+    value: metalDing07.wav
+  abstract-mLeft-down:
+    value: piano-short-E3.wav
+  special-secondaryMoving:
+    value: ''
+  abstract-scroll-end:
+    value: ''
+  abstract-mLeft-up:
+    value: piano-short-G3.wav
+  general-zone-pOOB-enter:
+    value: piano-short-C1.wav
+  abstract-trippleClick:
+    value: metalDing02.wav
+  abstract-scroll-early:
+    value: metalDing04.wav
+  general-state-pClosed-enter:
+    value: metalDing08.wav
+  bug:
+    value: coocoo1.wav
+  individual-pNonOOB0Open-enter:
+    value: ''
+  special-primaryMoving:
+    value: ''
+  special-primaryStationary:
     value: ''

--- a/examples/audio/justSecondary/README.md
+++ b/examples/audio/justSecondary/README.md
@@ -1,10 +1,6 @@
 # Just secondary
 
-Very similar to the default configuration, except that it only does it for the secondary hand. This is because you don't use the secondary hand any where near as often, and it's often not obvious whether you're making the desired gesture until you take action, which could lead to mistakes.
-
-This aims to solve that by helping you hear when you are making the gesture that you want.
-
-I suggest starting with the default, and then moving to this once you've mastered the default.
+Very basic notifications for the secondary hand. Silence for the primary hand.
 
 ## Notifications
 

--- a/examples/audio/justSecondary/audioEvents.yml
+++ b/examples/audio/justSecondary/audioEvents.yml
@@ -24,3 +24,31 @@ items:
     value: ''
   imposterHand-discard:
     value: ''
+  abstract-mLeft-down:
+    value: ""
+  abstract-mLeft-up:
+    value: ""
+  abstract-mLeft-click:
+    value: ""
+  abstract-mRight-down:
+    value: ""
+  abstract-mRight-up:
+    value: ""
+  abstract-mRight-click:
+    value: ""
+  abstract-mMiddle-down:
+    value: ""
+  abstract-mMiddle-up:
+    value: ""
+  abstract-mMiddle-click:
+    value: ""
+  abstract-doubleClick:
+    value: ""
+  abstract-trippleClick:
+    value: ""
+  abstract-scroll-early:
+    value: ""
+  abstract-scroll-begin:
+    value: ""
+  abstract-scroll-end:
+    value: ""

--- a/examples/audio/nothing/README.md
+++ b/examples/audio/nothing/README.md
@@ -2,7 +2,7 @@
 
 No audio notifications, but the audio is still enabled. This is so that future notifications can be enabled intuitively to train people on the new features.
 
-If you want total silence, you should check out the silence example.
+If you want total silence, you should check out the silence example. But be aware that that will auto silence the bug notification.
 
 ## Notifications
 

--- a/examples/audio/nothing/audioEvents.yml
+++ b/examples/audio/nothing/audioEvents.yml
@@ -24,3 +24,31 @@ items:
     value: ''
   imposterHand-discard:
     value: ''
+  abstract-mLeft-down:
+    value: ""
+  abstract-mLeft-up:
+    value: ""
+  abstract-mLeft-click:
+    value: ""
+  abstract-mRight-down:
+    value: ""
+  abstract-mRight-up:
+    value: ""
+  abstract-mRight-click:
+    value: ""
+  abstract-mMiddle-down:
+    value: ""
+  abstract-mMiddle-up:
+    value: ""
+  abstract-mMiddle-click:
+    value: ""
+  abstract-doubleClick:
+    value: ""
+  abstract-trippleClick:
+    value: ""
+  abstract-scroll-early:
+    value: ""
+  abstract-scroll-begin:
+    value: ""
+  abstract-scroll-end:
+    value: ""

--- a/examples/audio/piano/firstAttempt/audioEvents.yml
+++ b/examples/audio/piano/firstAttempt/audioEvents.yml
@@ -116,3 +116,31 @@ items:
     value: piano-short-C5.wav
   individual-sAction7Open-enter:
     value: piano-short-E5.wav
+  abstract-mLeft-down:
+    value: ""
+  abstract-mLeft-up:
+    value: ""
+  abstract-mLeft-click:
+    value: ""
+  abstract-mRight-down:
+    value: ""
+  abstract-mRight-up:
+    value: ""
+  abstract-mRight-click:
+    value: ""
+  abstract-mMiddle-down:
+    value: ""
+  abstract-mMiddle-up:
+    value: ""
+  abstract-mMiddle-click:
+    value: ""
+  abstract-doubleClick:
+    value: ""
+  abstract-trippleClick:
+    value: ""
+  abstract-scroll-early:
+    value: ""
+  abstract-scroll-begin:
+    value: ""
+  abstract-scroll-end:
+    value: ""

--- a/examples/audio/silence/README.md
+++ b/examples/audio/silence/README.md
@@ -1,3 +1,5 @@
 # Silence
 
 This turns off all audio feedback. I highly recommend using the nothing example instead so that you get assistance when new features are added. But if you simply want everything to shut up, this is an effective way of doing that.
+
+It's also important to still receive the bug notification, because that tells you when something is crashing, and will help you understand why so that you can fix it. This is rare these days, but still valuable.

--- a/examples/gestureLayouts/tiltClick/closeDoubleClick/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/closeDoubleClick/actionEvents.yml
@@ -1,7 +1,7 @@
 groups: {}
 items:
   general-zone-pAction-enter:
-    value: do-mDoubleClick-left();
+    value: simple-doubleLeftClick();
   general-segment-s0-enter:
     value: keyDown("ctrl");
   general-segment-s0-exit:

--- a/examples/gestureLayouts/tiltClick/closeDoubleClick/macros.yml
+++ b/examples/gestureLayouts/tiltClick/closeDoubleClick/macros.yml
@@ -2,7 +2,7 @@ groups: {}
 items:
   closedSlot0-overrideable-enter:
     description: Overrideable action to be performed when the closedSlot0 gesture is performed.
-    value: setButton("left");doubleClick();
+    value: simple-doubleLeftClick();
   closedSlot0-overrideable-exit:
     description: Overrideable action to be performed when the closedSlot0 gesture is finished.
     value: ''

--- a/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/doubleClick/actionEvents.yml
@@ -1,7 +1,7 @@
 groups: {}
 items:
   general-zone-pAction-enter:
-    value: do-mDoubleClick-left();
+    value: simple-doubleLeftClick();
   general-segment-s0-enter:
     value: keyDown("ctrl");
   general-segment-s0-exit:

--- a/examples/gestureLayouts/tiltClick/easyMiddleClick/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/easyMiddleClick/actionEvents.yml
@@ -1,7 +1,7 @@
 groups: {}
 items:
   general-zone-pAction-enter:
-    value: do-mDoubleClick-left();
+    value: simple-doubleLeftClick();
   general-segment-s0-enter:
     value: keyDown("ctrl");
   general-segment-s0-exit:

--- a/examples/gestureLayouts/tiltClick/easyMiddleClick/macros.yml
+++ b/examples/gestureLayouts/tiltClick/easyMiddleClick/macros.yml
@@ -2,7 +2,7 @@ groups: {}
 items:
   closedSlot0-overrideable-enter:
     description: Overrideable action to be performed when the closedSlot0 gesture is performed.
-    value: setButton("left");doubleClick();
+    value: simple-doubleLeftClick();
   closedSlot0-overrideable-exit:
     description: Overrideable action to be performed when the closedSlot0 gesture is finished.
     value: ''

--- a/examples/gestureLayouts/tiltClick/zoom/actionEvents.yml
+++ b/examples/gestureLayouts/tiltClick/zoom/actionEvents.yml
@@ -1,7 +1,7 @@
 groups: {}
 items:
   general-zone-pAction-enter:
-    value: do-mDoubleClick-left();
+    value: simple-doubleLeftClick();
   general-segment-s0-enter:
     value: keyDown("ctrl");
   general-segment-s0-exit:

--- a/src/main/java/handWavey/Gesture.java
+++ b/src/main/java/handWavey/Gesture.java
@@ -66,11 +66,11 @@ public class Gesture {
         overrideDefault(
             "general-state-pClosed-enter",
             "mDownAmbiguous();",
-            "");
+            "metalDing08.wav");
         overrideDefault(
             "general-state-pClosed-exit",
             "mUpAmbiguous();",
-            "");
+            "metalDing07.wav");
 
         // Set taps.
         overrideDefault(
@@ -161,10 +161,29 @@ public class Gesture {
             "");
 
         // General auido feedback.
-        this.audioEvents.getItem("general-zone-pAnyChange").overrideDefault("");
+        this.audioEvents.getItem("general-zone-pOOB-enter").overrideDefault("piano-short-C1.wav");
+        this.audioEvents.getItem("general-zone-pNoMove-enter").overrideDefault("piano-short-C2.wav");
+        this.audioEvents.getItem("general-zone-pActive-enter").overrideDefault("piano-short-C3.wav");
+        this.audioEvents.getItem("general-zone-pAction-enter").overrideDefault("piano-short-C4.wav");
         this.audioEvents.getItem("general-zone-sAnyChange").overrideDefault("metalDing03.wav");
         this.audioEvents.getItem("general-segment-pAnyChange").overrideDefault("");
         this.audioEvents.getItem("general-segment-sAnyChange").overrideDefault("metalDing04.wav");
+
+        // Final action audio feedback.
+        this.audioEvents.getItem("abstract-mLeft-down").overrideDefault("piano-short-E3.wav");
+        this.audioEvents.getItem("abstract-mLeft-up").overrideDefault("piano-short-G3.wav");
+        this.audioEvents.getItem("abstract-mLeft-click").overrideDefault("piano-short-G4.wav");
+        this.audioEvents.getItem("abstract-mRight-down").overrideDefault("piano-short-F3.wav");
+        this.audioEvents.getItem("abstract-mRight-up").overrideDefault("piano-short-A3.wav");
+        this.audioEvents.getItem("abstract-mRight-click").overrideDefault("piano-short-A4.wav");
+        this.audioEvents.getItem("abstract-mMiddle-down").overrideDefault("piano-short-F3.wav");
+        this.audioEvents.getItem("abstract-mMiddle-up").overrideDefault("piano-short-B3.wav");
+        this.audioEvents.getItem("abstract-mMiddle-click").overrideDefault("piano-short-B4.wav");
+        this.audioEvents.getItem("abstract-doubleClick").overrideDefault("metalDing01.wav");
+        this.audioEvents.getItem("abstract-trippleClick").overrideDefault("metalDing02.wav");
+        this.audioEvents.getItem("abstract-scroll-early").overrideDefault("metalDing04.wav");
+        this.audioEvents.getItem("abstract-scroll-begin").overrideDefault("metalDing03.wav");
+        this.audioEvents.getItem("abstract-scroll-end").overrideDefault("");
     }
 
     private void overrideDefault(String eventName, String actionLine, String audioNotification) {

--- a/src/main/java/handWavey/Gesture.java
+++ b/src/main/java/handWavey/Gesture.java
@@ -409,7 +409,7 @@ public class Gesture {
 
         switch (direction) {
             case Gesture.entering:
-                result = "enterint";
+                result = "entering";
                 break;
             case Gesture.exiting:
                 result = "exiting";

--- a/src/main/java/handWavey/Gesture.java
+++ b/src/main/java/handWavey/Gesture.java
@@ -60,39 +60,39 @@ public class Gesture {
         overrideDefault(
             "general-zone-pAction-enter",
             "do-mDoubleClick-left();",
-            "metalDing07.wav");
+            "");
 
         // Normal click behavior.
         overrideDefault(
             "general-state-pClosed-enter",
             "mDownAmbiguous();",
-            "metalDing07.wav");
+            "");
         overrideDefault(
             "general-state-pClosed-exit",
             "mUpAmbiguous();",
-            "metalDing08.wav");
+            "");
 
         // Set taps.
         overrideDefault(
             "tap-p0Open",
             "simple-leftClick();",
-            "metalDing08.wav");
+            "");
         overrideDefault(
             "tap-p1Open",
             "simple-rightClick();",
-            "metalDing08.wav");
+            "");
         overrideDefault(
             "tap-p2Open",
             "simple-middleClick();",
-            "metalDing08.wav");
+            "");
         overrideDefault(
             "tap-s0Open",
             "simple-rightClick();",
-            "metalDing05.wav");
+            "");
         overrideDefault(
             "tap-s0Closed",
             "simple-middleClick();",
-            "metalDing04.wav");
+            "");
 
         // Set buttons.
         overrideDefault(
@@ -161,9 +161,9 @@ public class Gesture {
             "");
 
         // General auido feedback.
-        this.audioEvents.getItem("general-zone-pAnyChange").overrideDefault("metalDing01.wav");
+        this.audioEvents.getItem("general-zone-pAnyChange").overrideDefault("");
         this.audioEvents.getItem("general-zone-sAnyChange").overrideDefault("metalDing03.wav");
-        this.audioEvents.getItem("general-segment-pAnyChange").overrideDefault("metalDing02.wav");
+        this.audioEvents.getItem("general-segment-pAnyChange").overrideDefault("");
         this.audioEvents.getItem("general-segment-sAnyChange").overrideDefault("metalDing04.wav");
     }
 

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -661,6 +661,9 @@ public class HandWaveyConfig {
             "",
             "When the secondary hand starts moving.");
 
+        audioEvents.addItemTemplate("abstract-.*", "", "A notification for an abstract action rather than a specific event.");
+
+
 
         this.config.newItem(
             "relativeSensitivity",
@@ -803,7 +806,7 @@ public class HandWaveyConfig {
 
         macrosGroup.newItem(
             "do-mDownLeft",
-            "setButton(\"left\");do-mDownAmbiguous();",
+            "setButton(\"left\");do-mDownAmbiguous();do(\"abstract-mLeft-down\");",
             "Mouse down - Left.");
 
         macrosGroup.newItem(
@@ -813,7 +816,7 @@ public class HandWaveyConfig {
 
         macrosGroup.newItem(
             "do-mDownRight",
-            "setButton(\"right\");do-mDownAmbiguous();",
+            "setButton(\"right\");do-mDownAmbiguous();do(\"abstract-mRight-down\");",
             "Mouse down - Right.");
 
         macrosGroup.newItem(
@@ -823,22 +826,22 @@ public class HandWaveyConfig {
 
         macrosGroup.newItem(
             "do-mDownMiddle",
-            "setButton(\"middle\");do-mDownAmbiguous();",
+            "setButton(\"middle\");do-mDownAmbiguous();do(\"abstract-mMiddle-down\");",
             "Mouse down - Middle.");
 
         macrosGroup.newItem(
             "mUpLeft",
-            "mUpAmbiguous();",
+            "mUpAmbiguous();do(\"abstract-mLeft-up\");",
             "Mouse up - Left.");
 
         macrosGroup.newItem(
             "mUpRight",
-            "mUpAmbiguous();",
+            "mUpAmbiguous();do(\"abstract-mRight-up\");",
             "Mouse up - Right.");
 
         macrosGroup.newItem(
             "mUpMiddle",
-            "mUpAmbiguous();",
+            "mUpAmbiguous();do(\"abstract-mMiddle-up\");",
             "Mouse up - Middle.");
 
         macrosGroup.newItem(
@@ -873,7 +876,7 @@ public class HandWaveyConfig {
 
         macrosGroup.newItem(
             "do-simple-leftClick",
-            "setButton(\"left\");do-simple-ambiguousClick();",
+            "setButton(\"left\");do-simple-ambiguousClick();do(\"abstract-mLeft-click\");",
             "Do the actual work of the left click from a tap. Intended to be called by simple-leftClick();");
 
         macrosGroup.newItem(
@@ -883,7 +886,7 @@ public class HandWaveyConfig {
 
         macrosGroup.newItem(
             "do-simple-rightClick",
-            "setButton(\"right\");do-simple-ambiguousClick();",
+            "setButton(\"right\");do-simple-ambiguousClick();do(\"abstract-mRight-click\");",
             "Do the actual work of the right click from a tap. Intended to be called by simple-rightClick();");
 
         macrosGroup.newItem(
@@ -893,8 +896,18 @@ public class HandWaveyConfig {
 
         macrosGroup.newItem(
             "do-simple-middleClick",
-            "setButton(\"middle\");do-simple-ambiguousClick();",
+            "setButton(\"middle\");do-simple-ambiguousClick();do(\"abstract-mMiddle-click\");",
             "Do the actual work of the middle click from a tap. Intended to be called by simple-middleClick();");
+
+        macrosGroup.newItem(
+            "simple-doubleLeftClick",
+            "delayedDo(\"do-mDoubleClick-left\", \"150\");",
+            "Perform a complete double-click.");
+
+        macrosGroup.newItem(
+            "do-mDoubleClick-left",
+            "lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();do(\"abstract-doubleClick\");",
+            "Perform a double left click right now.");
 
         macrosGroup.newItem(
             "simple-trippleLeftClick",
@@ -903,7 +916,7 @@ public class HandWaveyConfig {
 
         macrosGroup.newItem(
             "do-simple-trippleLeftClick",
-            "cancelAllDelayedDos();setButton(\"left\");lockCursor();rewindCursorPosition(\"150\");click();click();click();unlockCursor();",
+            "cancelAllDelayedDos();setButton(\"left\");lockCursor();rewindCursorPosition(\"150\");click();click();click();unlockCursor();do(\"abstract-trippleClick\");",
             "Do the work of a simple tripple click.");
 
         macrosGroup.newItem(
@@ -928,13 +941,8 @@ public class HandWaveyConfig {
 
         macrosGroup.newItem(
             "yankScroll-exit",
-            "cancelAllDelayedDos();unlockCursor();allowWheelClicks();setSlot(\"3\", \"\");rewindCursorPosition();releaseZone();unlockCursor();unlockTaps(\"primary\", \"800\");",
+            "cancelAllDelayedDos();unlockCursor();allowWheelClicks();setSlot(\"3\", \"\");rewindCursorPosition();releaseZone();unlockCursor();unlockTaps(\"primary\", \"800\");do(\"abstract-scroll-end\");",
             "Yank scrolling is the grab to scroll, where you need to yank it to get it started. The -exit macro puts it away.");
-
-        macrosGroup.newItem(
-            "do-mDoubleClick-left",
-            "lockCursor();rewindCursorPosition();releaseButtons();setButton(\"left\");doubleClick();",
-            "Perform a double left click right now.");
 
         macrosGroup.newItem(
             "do-mDoubleClickHold-left",
@@ -953,7 +961,7 @@ public class HandWaveyConfig {
 
         macrosGroup.newItem(
             "do-earlyScroll",
-            "rewindCursorPosition();overrideZone(\"scroll\");",
+            "rewindCursorPosition();overrideZone(\"scroll\");do(\"abstract-scroll-early\");",
             "");
 
         macrosGroup.newItem(
@@ -963,7 +971,7 @@ public class HandWaveyConfig {
 
         macrosGroup.newItem(
             "do-scroll",
-            "cancelAllDelayedDos();rewindCursorPosition();overrideZone(\"scroll\");setSlot(\"3\", \"\");delayedDo(\"disallowWheelClicks\", \"150\");lockTaps(\"primary\");",
+            "cancelAllDelayedDos();rewindCursorPosition();overrideZone(\"scroll\");setSlot(\"3\", \"\");delayedDo(\"disallowWheelClicks\", \"150\");lockTaps(\"primary\");do(\"abstract-scroll-begin\");",
             "");
 
         macrosGroup.newItem(

--- a/src/main/java/handWavey/HandWaveyEvent.java
+++ b/src/main/java/handWavey/HandWaveyEvent.java
@@ -80,7 +80,9 @@ public class HandWaveyEvent {
         this.shouldCompleteEvent.finish();
     }
 
-    public void triggerSubEvent(String eventName, String indent) {
+    public Boolean triggerSubEvent(String eventName, String indent) {
+        Boolean result = false;
+
         // Get the info we need for the event.
         String macroLine = this.getEventAction(eventName);
         String fileToPlay = "";
@@ -98,13 +100,17 @@ public class HandWaveyEvent {
         if (doMacro) {
             this.debug.out(2, indent + "  macroLine: \"" + macroLine + "\"");
             this.macroLine.runLine(macroLine);
+            result = true;
         }
 
         // Do Audio.
         if (doAudio) {
             this.debug.out(2, indent + "  fileToPlay: \"" + fileToPlay + "\"");
             BackgroundSound.play(fileToPlay);
+            result = true;
         }
+
+        return result;
     }
 
     private long timeInMilliseconds() {

--- a/src/main/java/macro/MacroCore.java
+++ b/src/main/java/macro/MacroCore.java
@@ -278,11 +278,8 @@ public class MacroCore {
             this.debug.out(2, "Internal instruction \"" + commandToTry + "\" does not exist.");
             if (!this.tryMacro(commandToTry)) {
                 this.debug.out(2, "Macro \"" + commandToTry + "\" does not exist.");
-                if (!this.events.itemExists(commandToTry)) {
+                if (!this.handWaveyEvent.triggerSubEvent(commandToTry, indent)) {
                     this.debug.out(0, commandToTry + " doesn't appear to be a macro or event.");
-                } else {
-                    this.debug.out(2, "Event \"" + commandToTry + "\" exists. Triggering that.");
-                    this.handWaveyEvent.triggerSubEvent(commandToTry, indent);
                 }
             }
         }


### PR DESCRIPTION
## Background

Until this time, audio notifications have been for notifying the user about what gestures they are performing.

## The change

This PR implements abstract notifications for the actual actions being performed. 

These will make the same noises regardless of which gestureLayout is being used, which will help migrating between gestureLayouts.

I've chosen audio notifications that sound pleasant when compatible actions happen together, and sound bad when likely-incompatible actions happen together. Eg:

* Hand enters + left down then left up, will play C E G. (Should sound nice.)
* Hand enters + right down then right up, will play C F A. (Should sound nice.)
* Hand enters + left up + right up will play C G A. (Should sound bad.)

The [traditional notification styles](https://github.com/ksandom/handWavey/tree/main/examples/audio) still exist, and should remain compatible long term.