### PR TITLE
Reduce false taps

### DIFF
--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -779,7 +779,7 @@ public class HandWaveyConfig {
         Group tap = this.config.newGroup("tap");
         tap.newItem(
             "preTapTime",
-            "50",
+            "100",
             "The minimum amount of time that the hand must not be moving on the Z axis before a tap can be performed.");
         tap.newItem(
             "tapSpeed",


### PR DESCRIPTION
Require the hand to be stable for slightly longer before allowing a tap to be performed.

I've messed with this value quite a bit to find what I like the best. Right now it's at a clean 100, but I'll continue to re-evaluate this as testing reveals more edge cases.