### PR TITLE
Add scroll bumping

### DIFF
--- a/docs/user/howTo/scroll.md
+++ b/docs/user/howTo/scroll.md
@@ -71,3 +71,11 @@ Consult your [gestureLayout](https://github.com/ksandom/handWavey/tree/main/exam
 
 * [tiltClick](https://github.com/ksandom/handWavey/tree/main/examples/gestureLayouts/tiltClick) based gestureLayouts typically work by grabbing the thing you want to scroll and then pulling it in the direction you want it to go. Let go when you're done.
 * [grabClick](https://github.com/ksandom/handWavey/tree/main/examples/gestureLayouts/grabClick) based gestureLayouts typically work by turning your hand up-side-down and moving your hand in the direction you want it to go. Turn your hand back up right when you're done.
+
+### Scroll bumping
+
+Within joystick scrolling, you can "bump" the scroll by one notch by quickly exiting the dead zone, and re-entering it. You perform the bump in the direction that you want to scroll.
+
+This is implemented as an extra scroll event using the `special-scrollBump-up` and `special-scrollBump-down` events.
+
+It's handy for when you want to scroll finely, which is a little more difficult in joystick scrolling.

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -630,6 +630,15 @@ public class HandWaveyConfig {
             "special-scrolling-stop",
             "unlockTaps(\"primary\");allowWheelClicks();",
             "When the scrolling motion ends.");
+        actionEvents.newItem(
+            "special-scrollBump-up",
+            "scroll(\"1\");",
+            "In joystick scroll, we can \"bump\" the scroll by one step by quickly exiting the dead zone and then re-entering it. Up vs down defines the direction.");
+        actionEvents.newItem(
+            "special-scrollBump-down",
+            "scroll(\"-1\");",
+            "In joystick scroll, we can \"bump\" the scroll by one step by quickly exiting the dead zone and then re-entering it. Up vs down defines the direction.");
+
         this.generateCustomConfig(actionEvents);
 
         Group audioConfig = this.config.newGroup("audioConfig");

--- a/src/main/java/handWavey/Motion.java
+++ b/src/main/java/handWavey/Motion.java
@@ -584,6 +584,12 @@ public final class Motion {
             } else {
                 this.handWaveyManager.triggerEvent("abstract-scroll-deadZone-exit");
                 this.handWaveyManager.triggerEvent("special-scrolling-start");
+
+                if (totalDistanceY > 0) {
+                    this.handWaveyManager.triggerEvent("special-scrollBump-up");
+                } else {
+                    this.handWaveyManager.triggerEvent("special-scrollBump-down");
+                }
             }
         }
 

--- a/src/main/java/macro/MacroCore.java
+++ b/src/main/java/macro/MacroCore.java
@@ -140,6 +140,9 @@ public class MacroCore {
             case "setButton":
                 this.handsState.setMouseButton(parm(parameters, 0, "left"));
                 break;
+            case "scroll":
+                scroll(parm(parameters, 0, "1"));
+                break;
 
             // Keyboard instructions.
             case "keyDown":
@@ -321,6 +324,14 @@ public class MacroCore {
         } else {
             this.debug.out(2, "Would have run slot " + String.valueOf(slot) + " == " + eventToRun + ". Previous value: " + previousValue + ". But slots are currently disabled.");
             return "";
+        }
+    }
+
+    private void scroll(String direction) {
+        if (direction.equals("-1")) {
+            this.output.scroll(-1);
+        } else {
+            this.output.scroll(1);
         }
     }
 


### PR DESCRIPTION
In joystick scrolling, you can now "bump" the scroll by a single notch in the direction that you want to scroll, by quickly exiting the dead zone and then re-entering it.

This makes it really easy to do a single step, which was previously a weak point of joystick scrolling.