### PR TITLE
Ensure that audio is always initialised early

### DIFF
--- a/src/main/java/audio/BackgroundSound.java
+++ b/src/main/java/audio/BackgroundSound.java
@@ -90,7 +90,7 @@ public class BackgroundSound extends Thread {
         }
     }
 
-    private static void setup() {
+    public static void setup() {
         // Immediately return if it's already configured.
         if (BackgroundSound.configured) {
             return ;
@@ -107,5 +107,7 @@ public class BackgroundSound extends Thread {
 
         // Make sure we don't do this again for this session.
         BackgroundSound.configured = true;
+
+        BackgroundSound.debug.out(1, "Finished sound setup.");
     }
 }

--- a/src/main/java/handWavey/HandWaveyManager.java
+++ b/src/main/java/handWavey/HandWaveyManager.java
@@ -91,6 +91,8 @@ public final class HandWaveyManager {
         this.shouldCompleteSFO = new ShouldComplete("figureStuffOut");
 
         reloadConfig();
+
+        BackgroundSound.setup();
     }
 
     private void loadAndSaveConfigToDisk() {


### PR DESCRIPTION
This prevents two things initialising it later at the same time.

I was hoping that this was going to fix/reduce [the segfaults](https://github.com/ksandom/handWavey/issues/6). It didn't, but it's still a good thing to do, so I've decided to push it anyway.