### PR TITLE
Add moveBeforeTaps

### DIFF
--- a/docs/user/reference/moveBeforeAction.md
+++ b/docs/user/reference/moveBeforeAction.md
@@ -1,0 +1,22 @@
+# Move before action
+
+* Problem: The LeapMotion controller is quite noisy when the hand is first introduced, which causes unwanted actions. So we don't allow any action to be taken for a period of time after the hand is introduced to allow it to stabilise. But this timing is really hard to get right.
+* Assumptions:
+    * We don't normally intend to perform an action before having first moved the mouse cursor.
+    * The LeapMotion controller has usually had plenty of time to stabilise by the time we have the mouse cursor where we want it.
+* Solution: Keep actions locked until the cursor is relatively stationary.
+* Consequences:
+    * If you want to be able to perform actions without moving the cursor beforehand, they won't work. For this reason, the setting is optional.
+
+## General
+
+There is a small wait between the hand arriving, and actions being allowed.
+
+* Configure in: [yourConfigurationDirectory](https://github.com/ksandom/handWavey/blob/main/docs/user/configuration/whereIsMyConfigurationDirectory.md)/handCleaner.yml
+* Setting name: `minHandAge`
+
+## Taps
+
+* Configure in: [yourConfigurationDirectory](https://github.com/ksandom/handWavey/blob/main/docs/user/configuration/whereIsMyConfigurationDirectory.md)/tap.yml
+* Setting name: `moveBeforeTaps`
+* Default: `true`

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -800,6 +800,10 @@ public class HandWaveyConfig {
             "stationarySpeed",
             "22",
             "The speed, below which, the hand is considered stationary, and segment/state changes will be allowed. This is called speedLock. Setting this to -1 disables the speedLock. Change the debug level for HandsState to at least 2 to see the live speeds when the lock engages and disengages. You'll need stationarySpeed to be set to something positive for this to work. I suggest starting around 5-10.");
+        handCleaner.newItem(
+            "minHandAge",
+            "150",
+            "The number of milliseconds that a hand must be present before \"moveBefore____\" decisions can be made.");
 
         Group tap = this.config.newGroup("tap");
         tap.newItem(
@@ -822,6 +826,10 @@ public class HandWaveyConfig {
             "postTapTime",
             "100",
             "The minimum amount of time that the hand must not be moving more than tapSpeed after performing the tap.");
+        tap.newItem(
+            "moveBeforeTaps",
+            "true",
+            "Do you have to move the cursor before you can perform taps? (true or false). This prevents accidentally accidental taps when introducing a hand, but is also easy to unlock. If stationarySpeed in handCleaner is set to -1, you will never be able to tap when moveBeforeTaps is enabled.");
 
         Group macros = this.config.newGroup("macros");
         generateMacroConfig(macros);


### PR DESCRIPTION
This options disables taps until the cursor has been moved.

From the documentation:

* Problem: The LeapMotion controller is quite noisy when the hand is first introduced, which causes unwanted actions. So we don't allow any action to be taken for a period of time after the hand is introduced to allow it to stabilise. But this timing is really hard to get right.
* Assumptions:
    * We don't normally intend to perform an action before having first moved the mouse cursor.
    * The LeapMotion controller has usually had plenty of time to stabilise by the time we have the mouse cursor where we want it.
* Solution: Keep actions locked until the cursor is relatively stationary.
* Consequences:
    * If you want to be able to perform actions without moving the cursor beforehand, they won't work. For this reason, the setting is optional.

## General

There is a small wait between the hand arriving, and actions being allowed.

* Configure in: [yourConfigurationDirectory](https://github.com/ksandom/handWavey/blob/main/docs/user/configuration/whereIsMyConfigurationDirectory.md)/handCleaner.yml
* Setting name: `minHandAge`

## Taps

* Configure in: [yourConfigurationDirectory](https://github.com/ksandom/handWavey/blob/main/docs/user/configuration/whereIsMyConfigurationDirectory.md)/tap.yml
* Setting name: `moveBeforeTaps`
* Default: `true`
