### PR TITLE
Add moveBeforeTimeout

### DIFF
--- a/docs/user/reference/moveBeforeAction.md
+++ b/docs/user/reference/moveBeforeAction.md
@@ -13,7 +13,8 @@
 There is a small wait between the hand arriving, and actions being allowed.
 
 * Configure in: [yourConfigurationDirectory](https://github.com/ksandom/handWavey/blob/main/docs/user/configuration/whereIsMyConfigurationDirectory.md)/handCleaner.yml
-* Setting name: `minHandAge`
+* Setting name: `minHandAge` - Milliseconds that must have elapsed since the introduction of the hand before actions can be unlocked.
+* Setting name: `moreBeforeTimeout` - Milliseconds to wait since the introduction of the handbefore allowing actions to be performed normally.
 
 ## Taps
 

--- a/src/main/java/handWavey/HandWaveyConfig.java
+++ b/src/main/java/handWavey/HandWaveyConfig.java
@@ -804,6 +804,10 @@ public class HandWaveyConfig {
             "minHandAge",
             "150",
             "The number of milliseconds that a hand must be present before \"moveBefore____\" decisions can be made.");
+        handCleaner.newItem(
+            "moveBeforeTimeout",
+            "1500",
+            "If the moveBefore configuration has taken too long to succeed, this is the last ditch effort to get handWavey into a usable state. It's the number of milliseconds after the hand was introduced, and is expected to be a large number, like 1500 (1.5 seconds). It can happen naturally if the user hovers, but doesn't move anywhere before trying to perform an action. It's not ideal (because the user potentially waited longer than they would expect), but at least it's likely to loosely behave the way they'd expect.");
 
         Group tap = this.config.newGroup("tap");
         tap.newItem(


### PR DESCRIPTION
If the moveBefore configuration has taken too long to succeed, this is the last ditch effort to get handWavey into a usable state. It's the number of milliseconds after the hand was introduced, and is expected to be a large number, like 1500 (1.5 seconds). It can happen naturally if the user hovers, but doesn't move anywhere before trying to perform an action. It's not ideal (because the user potentially waited longer than they would expect), but at least it's likely to loosely behave the way they'd expect.