### PR TITLE
Make auto-trim behave better with merged segments

### DIFF
--- a/src/main/java/handWavey/Gesture.java
+++ b/src/main/java/handWavey/Gesture.java
@@ -149,7 +149,7 @@ public class Gesture {
             "");
         overrideDefault(
             "general-segment-p0-enter",
-            "stabliseNeutralPosition();",
+            "",
             "");
         overrideDefault(
             "special-newHandUnfreezeEvent",

--- a/src/main/java/handWavey/HandCleaner.java
+++ b/src/main/java/handWavey/HandCleaner.java
@@ -303,7 +303,7 @@ public class HandCleaner {
 
         long now = this.timeInMilliseconds();
         long elapsed = now - lastChangeTime;
-        lastChangeTime = timeInMilliseconds();
+        lastChangeTime = now;
         double seconds = elapsed / 1000F;
 
         double distancePerSecond = distance / seconds;


### PR DESCRIPTION
Previously auto-trim would treat each segment in a merged block of segments as if it was still an individual segment. This caused it to trim in unintuitive ways, which lead to erratic slingshotting when coming out of a merged segment.

This change works by treating the merged segments as a whole, and only acting on the edges of the total block.